### PR TITLE
chore(infra): PR マージ時に GitHub Project ステータスを自動更新

### DIFF
--- a/.github/workflows/project-automation.yml
+++ b/.github/workflows/project-automation.yml
@@ -1,0 +1,80 @@
+name: Project Automation
+
+on:
+  pull_request:
+    types: [closed]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  move-to-done:
+    name: Move linked issues to Done
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+
+    steps:
+      - name: Move issues to Done in GitHub Project
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          PROJECT_ID: "PVT_kwHOArXseM4BRwSj"
+          STATUS_FIELD_ID: "PVTSSF_lAHOArXseM4BRwSjzg_fT98"
+          DONE_OPTION_ID: "448bcca5"
+          REPO: ${{ github.repository }}
+        run: |
+          # PR 本文から "Closes #N" / "Fixes #N" / "Resolves #N" のIssue番号を抽出
+          ISSUE_NUMBERS=$(echo "$PR_BODY" | grep -oiE '(closes|fixes|resolves) #[0-9]+' | grep -oE '[0-9]+' || true)
+
+          if [ -z "$ISSUE_NUMBERS" ]; then
+            echo "No linked issues found in PR body. Skipping."
+            exit 0
+          fi
+
+          for ISSUE_NUMBER in $ISSUE_NUMBERS; do
+            echo "Processing Issue #$ISSUE_NUMBER ..."
+
+            # Issue の node_id を取得
+            ISSUE_NODE_ID=$(gh api "repos/$REPO/issues/$ISSUE_NUMBER" --jq '.node_id')
+            echo "  node_id: $ISSUE_NODE_ID"
+
+            # Issue に紐づくプロジェクトアイテムのIDを取得
+            ITEM_ID=$(gh api graphql -f query="
+              query {
+                node(id: \"$ISSUE_NODE_ID\") {
+                  ... on Issue {
+                    projectItems(first: 10) {
+                      nodes {
+                        id
+                        project { id }
+                      }
+                    }
+                  }
+                }
+              }
+            " --jq ".data.node.projectItems.nodes[] | select(.project.id == \"$PROJECT_ID\") | .id")
+
+            if [ -z "$ITEM_ID" ]; then
+              echo "  Issue #$ISSUE_NUMBER is not in the project. Skipping."
+              continue
+            fi
+
+            echo "  item_id: $ITEM_ID"
+
+            # ステータスを Done に更新
+            gh api graphql -f query="
+              mutation {
+                updateProjectV2ItemFieldValue(input: {
+                  projectId: \"$PROJECT_ID\"
+                  itemId: \"$ITEM_ID\"
+                  fieldId: \"$STATUS_FIELD_ID\"
+                  value: { singleSelectOptionId: \"$DONE_OPTION_ID\" }
+                }) {
+                  projectV2Item { id }
+                }
+              }
+            "
+
+            echo "  ✅ Issue #$ISSUE_NUMBER moved to Done."
+          done


### PR DESCRIPTION
## Summary

PR がマージされると、本文の `Closes #N` に紐づく Issue のカンバンステータスが自動で **Done** に移動するワークフローを追加。

Closes #3

## 変更内容

- `.github/workflows/project-automation.yml` を追加
- `pull_request: closed` イベントでトリガー（merged のみ実行）
- PR 本文から `Closes / Fixes / Resolves #N` パターンを抽出
- Issue の `node_id` → `projectItems` GraphQL クエリ → `updateProjectV2ItemFieldValue` で Done に更新

## 必要な事前設定

`PROJECT_AUTOMATION_TOKEN` シークレットの登録が必要：

1. https://github.com/settings/tokens?type=beta で Fine-grained PAT を作成
   - Repository: `nakamu12/lumineer`
   - Permissions → **Projects: Read and write**
2. 登録:
   ```bash
   gh secret set PROJECT_AUTOMATION_TOKEN --body "github_pat_xxxx..."
   ```

## Test plan

- [ ] `PROJECT_AUTOMATION_TOKEN` シークレット登録
- [ ] テスト用 PR を作成し `Closes #N` を本文に含めてマージ
- [ ] 該当 Issue のステータスが Done に変わることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)