### PR TITLE
fix(infra): worktree 作成前に develop を pull してから分岐するよう修正

### DIFF
--- a/.claude/skills/lumineer-issue-start.md
+++ b/.claude/skills/lumineer-issue-start.md
@@ -93,16 +93,15 @@ git rev-parse --show-toplevel
 
 ### 4-1. develop を最新化してワークツリーを作成
 ```bash
-# develop を最新化
-git fetch origin develop
+# どのブランチにいても develop に切り替えて最新化
 git checkout develop
 git pull origin develop
 
 # worktree ディレクトリを確保（初回のみ）
 mkdir -p {project_root}/../worktree
 
-# worktree を作成（develop から新しいブランチを分岐）
-git worktree add {worktree_path} -b {branch_name} origin/develop
+# プルした develop を起点にワークツリーを作成
+git worktree add {worktree_path} -b {branch_name} develop
 ```
 
 ### 4-2. リモートへ push


### PR DESCRIPTION
## Summary

`git worktree add` のベースを `origin/develop`（fetch 前は stale の可能性）から、`git pull` 後のローカル `develop` に変更。

## 変更内容

```bash
# Before
git fetch origin develop
git checkout develop
git pull origin develop
git worktree add {path} -b {branch} origin/develop  # ← stale の可能性

# After
git checkout develop
git pull origin develop                              # ← 必ず最新化
git worktree add {path} -b {branch} develop         # ← pull 済みを起点に
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)