### PR TITLE
feat(frontend): ホームページ UI ポリッシュ（グラデーション・ビジュアル改善）

### DIFF
--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -17,6 +17,7 @@
         "react-router-dom": "^6.22.3",
         "sonner": "^1.4.41",
         "tailwind-merge": "^2.2.2",
+        "tailwindcss-animate": "^1.0.7",
       },
       "devDependencies": {
         "@testing-library/jest-dom": "^6.4.2",
@@ -834,6 +835,8 @@
     "tailwind-merge": ["tailwind-merge@2.6.1", "", {}, "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ=="],
 
     "tailwindcss": ["tailwindcss@3.4.19", "", { "dependencies": { "@alloc/quick-lru": "^5.2.0", "arg": "^5.0.2", "chokidar": "^3.6.0", "didyoumean": "^1.2.2", "dlv": "^1.1.3", "fast-glob": "^3.3.2", "glob-parent": "^6.0.2", "is-glob": "^4.0.3", "jiti": "^1.21.7", "lilconfig": "^3.1.3", "micromatch": "^4.0.8", "normalize-path": "^3.0.0", "object-hash": "^3.0.0", "picocolors": "^1.1.1", "postcss": "^8.4.47", "postcss-import": "^15.1.0", "postcss-js": "^4.0.1", "postcss-load-config": "^4.0.2 || ^5.0 || ^6.0", "postcss-nested": "^6.2.0", "postcss-selector-parser": "^6.1.2", "resolve": "^1.22.8", "sucrase": "^3.35.0" }, "bin": { "tailwind": "lib/cli.js", "tailwindcss": "lib/cli.js" } }, "sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ=="],
+
+    "tailwindcss-animate": ["tailwindcss-animate@1.0.7", "", { "peerDependencies": { "tailwindcss": ">=3.0.0 || insiders" } }, "sha512-bl6mpH3T7I3UFxuvDEXLxy/VuFxBk5bbzplh7tXI68mwMokNYd1t9qPBHlnyTwfa4JGC4zP516I1hYYtQ/vspA=="],
 
     "text-table": ["text-table@0.2.0", "", {}, "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw=="],
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,7 +22,8 @@
     "react-dom": "^18.0.0",
     "react-router-dom": "^6.22.3",
     "sonner": "^1.4.41",
-    "tailwind-merge": "^2.2.2"
+    "tailwind-merge": "^2.2.2",
+    "tailwindcss-animate": "^1.0.7"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.4.2",

--- a/frontend/src/features/home/HomePage.tsx
+++ b/frontend/src/features/home/HomePage.tsx
@@ -1,5 +1,5 @@
 import { Link } from "react-router-dom"
-import { Search, BookOpen, Target, Map } from "lucide-react"
+import { Search, BookOpen, Target, Map, Zap, Users, GraduationCap } from "lucide-react"
 import { Button } from "@/lib/ui/button"
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/lib/ui/card"
 
@@ -7,61 +7,162 @@ const features = [
   {
     icon: Search,
     title: "Smart Course Search",
-    description: "Find the perfect course using natural language. Our AI understands what you want to learn.",
+    description:
+      "Find the perfect course using natural language. Our AI understands what you want to learn.",
+    iconColor: "text-teal-500",
+    glowColor: "group-hover:shadow-teal-500/20",
+    borderColor: "hover:border-teal-500/30",
+    bgGradient: "from-teal-500/5 to-transparent",
   },
   {
     icon: Target,
     title: "Skill Gap Analysis",
-    description: "Discover what skills you need to reach your goals and get personalized course recommendations.",
+    description:
+      "Discover what skills you need to reach your goals and get personalized course recommendations.",
+    iconColor: "text-blue-500",
+    glowColor: "group-hover:shadow-blue-500/20",
+    borderColor: "hover:border-blue-500/30",
+    bgGradient: "from-blue-500/5 to-transparent",
   },
   {
     icon: Map,
     title: "Learning Path Generation",
-    description: "Get a structured learning roadmap tailored to your timeline and objectives.",
+    description:
+      "Get a structured learning roadmap tailored to your timeline and objectives.",
+    iconColor: "text-teal-400",
+    glowColor: "group-hover:shadow-teal-400/20",
+    borderColor: "hover:border-teal-400/30",
+    bgGradient: "from-teal-400/5 to-transparent",
+  },
+]
+
+const stats = [
+  {
+    icon: GraduationCap,
+    value: "6,645+",
+    label: "Courses",
+    iconColor: "text-teal-500",
+  },
+  {
+    icon: Zap,
+    value: "AI-Powered",
+    label: "Search & Analysis",
+    iconColor: "text-blue-500",
+  },
+  {
+    icon: Users,
+    value: "3 Agents",
+    label: "Working for You",
+    iconColor: "text-teal-400",
   },
 ]
 
 export function HomePage() {
   return (
-    <div className="flex flex-col gap-16">
+    <div className="flex flex-col gap-20">
       {/* Hero */}
-      <section className="flex flex-col items-center gap-6 pt-12 text-center">
-        <div className="flex items-center gap-2">
-          <BookOpen className="h-8 w-8 text-primary" />
-          <span className="text-lg font-semibold text-muted-foreground">Lumineer</span>
+      <section className="relative flex flex-col items-center gap-8 pt-16 text-center">
+        {/* Background blob */}
+        <div
+          className="pointer-events-none absolute inset-0 -z-10 overflow-hidden"
+          aria-hidden="true"
+        >
+          <div className="absolute left-1/2 top-0 h-[600px] w-[600px] -translate-x-1/2 -translate-y-1/4 rounded-full bg-gradient-radial from-teal-500/10 via-blue-500/5 to-transparent blur-3xl" />
         </div>
-        <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
+
+        {/* Badge */}
+        <div className="flex items-center gap-2 rounded-full border border-teal-500/20 bg-teal-500/5 px-4 py-1.5">
+          <BookOpen className="h-4 w-4 text-teal-500" />
+          <span className="text-sm font-medium text-teal-600 dark:text-teal-400">
+            Intelligent Course Discovery
+          </span>
+        </div>
+
+        {/* Heading */}
+        <h1 className="max-w-3xl text-5xl font-bold tracking-tight sm:text-6xl">
           Illuminate Your
           <br />
-          <span className="text-primary">Learning Journey</span>
+          <span className="bg-gradient-to-r from-teal-500 to-blue-500 bg-clip-text text-transparent">
+            Learning Journey
+          </span>
         </h1>
+
         <p className="max-w-xl text-lg text-muted-foreground">
-          Discover the perfect courses from 6,645+ Coursera offerings. AI-powered search, skill gap analysis,
-          and personalized learning paths — all in one place.
+          Discover the perfect courses from 6,645+ Coursera offerings. AI-powered search, skill
+          gap analysis, and personalized learning paths — all in one place.
         </p>
-        <div className="flex gap-4">
-          <Button asChild size="lg">
-            <Link to="/chat">Start Learning</Link>
+
+        {/* CTA buttons */}
+        <div className="flex flex-wrap justify-center gap-4">
+          <Button
+            asChild
+            size="lg"
+            className="relative overflow-hidden bg-gradient-to-r from-teal-500 to-teal-600 text-white shadow-lg shadow-teal-500/25 transition-all hover:scale-105 hover:shadow-teal-500/40"
+          >
+            <Link to="/chat">
+              <Zap className="mr-2 h-4 w-4" />
+              Start Learning
+            </Link>
           </Button>
-          <Button asChild variant="outline" size="lg">
+          <Button
+            asChild
+            variant="outline"
+            size="lg"
+            className="border-teal-500/30 transition-all hover:scale-105 hover:border-teal-500/60 hover:bg-teal-500/5"
+          >
             <Link to="/explore">Explore Courses</Link>
           </Button>
         </div>
       </section>
 
-      {/* Features */}
+      {/* Stats */}
       <section className="grid gap-6 sm:grid-cols-3">
-        {features.map((feature) => (
-          <Card key={feature.title}>
-            <CardHeader>
-              <feature.icon className="h-8 w-8 text-primary" />
-              <CardTitle className="text-lg">{feature.title}</CardTitle>
-            </CardHeader>
-            <CardContent>
-              <CardDescription>{feature.description}</CardDescription>
-            </CardContent>
-          </Card>
+        {stats.map((stat) => (
+          <div
+            key={stat.label}
+            className="flex flex-col items-center gap-2 rounded-xl border border-border/50 bg-card/50 py-6 text-center backdrop-blur-sm"
+          >
+            <stat.icon className={`h-6 w-6 ${stat.iconColor}`} />
+            <span className="text-2xl font-bold">{stat.value}</span>
+            <span className="text-sm text-muted-foreground">{stat.label}</span>
+          </div>
         ))}
+      </section>
+
+      {/* Features */}
+      <section className="flex flex-col gap-8">
+        <div className="text-center">
+          <h2 className="text-2xl font-semibold tracking-tight">Everything you need to learn smarter</h2>
+          <p className="mt-2 text-muted-foreground">
+            Three AI agents working together to accelerate your growth
+          </p>
+        </div>
+
+        <div className="grid gap-6 sm:grid-cols-3">
+          {features.map((feature) => (
+            <Card
+              key={feature.title}
+              className={`group relative overflow-hidden border transition-all duration-300 ${feature.borderColor} hover:-translate-y-1 hover:shadow-lg ${feature.glowColor}`}
+            >
+              {/* Subtle gradient background */}
+              <div
+                className={`pointer-events-none absolute inset-0 bg-gradient-to-br ${feature.bgGradient} opacity-0 transition-opacity duration-300 group-hover:opacity-100`}
+                aria-hidden="true"
+              />
+              <CardHeader className="relative">
+                <div
+                  className={`mb-1 inline-flex h-10 w-10 items-center justify-center rounded-lg bg-muted/60 transition-all duration-300 group-hover:scale-110 ${feature.iconColor}`}
+                >
+                  <feature.icon className="h-5 w-5" />
+                </div>
+                <CardTitle className="text-lg">{feature.title}</CardTitle>
+              </CardHeader>
+              <CardContent className="relative">
+                <CardDescription>{feature.description}</CardDescription>
+              </CardContent>
+            </Card>
+          ))}
+        </div>
       </section>
     </div>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -57,3 +57,12 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+  .gradient-text {
+    @apply bg-gradient-to-r from-teal-500 to-blue-500 bg-clip-text text-transparent;
+  }
+  .gradient-text-primary {
+    @apply bg-gradient-to-r from-teal-400 via-teal-500 to-blue-500 bg-clip-text text-transparent;
+  }
+}

--- a/frontend/src/lib/layout/Header.tsx
+++ b/frontend/src/lib/layout/Header.tsx
@@ -17,8 +17,10 @@ export function Header() {
     <header className="sticky top-0 z-50 w-full border-b bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60">
       <div className="container flex h-14 items-center">
         <Link to="/" className="flex items-center gap-2 font-semibold">
-          <BookOpen className="h-5 w-5 text-primary" />
-          <span className="text-primary">Lumineer</span>
+          <BookOpen className="h-5 w-5 text-teal-500" />
+          <span className="bg-gradient-to-r from-teal-500 to-blue-500 bg-clip-text text-transparent">
+            Lumineer
+          </span>
         </Link>
         <nav className="ml-auto flex items-center gap-1">
           {navItems.map((item) => (

--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -70,7 +70,11 @@ export default {
         "accordion-down": "accordion-down 0.2s ease-out",
         "accordion-up": "accordion-up 0.2s ease-out",
       },
+      backgroundImage: {
+        "gradient-radial": "radial-gradient(var(--tw-gradient-stops))",
+        "gradient-conic": "conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))",
+      },
     },
   },
-  plugins: [],
+  plugins: [require("tailwindcss-animate")],
 }


### PR DESCRIPTION
## Summary

- Hero セクションに放射状グラデーション背景とグラデーションテキストを追加
- CTA ボタンにホバーグロー・スケールアニメーション
- Feature カードに hover elevation・アイコングロー効果
- Stats セクション追加（6,645+ Courses / AI-Powered / 3 Agents）
- Header の Lumineer ロゴにグラデーションカラー
- `tailwindcss-animate` プラグイン追加

## Test plan

- [ ] `bun dev` でグラデーション・アニメーションが表示される
- [ ] `bun run typecheck` がパスする
- [ ] ライトモードで見栄えが良い

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)