### PR TITLE
feat(frontend): Explore ページ実装（検索バー + コースカードグリッド）

### DIFF
--- a/frontend/src/features/explore/ExplorePage.tsx
+++ b/frontend/src/features/explore/ExplorePage.tsx
@@ -1,24 +1,158 @@
-import { Search } from "lucide-react"
+import { useState } from "react"
+import { Search, AlertCircle, BookOpen, Loader2 } from "lucide-react"
 import { Input } from "@/lib/ui/input"
 import { Button } from "@/lib/ui/button"
+import { CourseCard } from "./components/CourseCard"
+import { CourseCardSkeleton } from "./components/CourseCardSkeleton"
+import { SearchFilters, type LevelFilter, type RatingFilter } from "./components/SearchFilters"
+import { AiSummaryPanel } from "./components/AiSummaryPanel"
+import { useCourseSearch } from "./hooks/useCourseSearch"
+
+const SKELETON_COUNT = 6
 
 export function ExplorePage() {
+  const [query, setQuery] = useState("")
+  const [level, setLevel] = useState<LevelFilter>("")
+  const [minRating, setMinRating] = useState<RatingFilter>("")
+
+  const { courses, total, aiSummary, isLoading, error, hasMore, loadMore } = useCourseSearch({
+    query,
+    level,
+    minRating,
+  })
+
+  const handleClearFilters = () => {
+    setLevel("")
+    setMinRating("")
+  }
+
+  const hasQuery = query.trim().length > 0
+  const hasResults = courses.length > 0
+  const showEmpty = hasQuery && !isLoading && !error && !hasResults
+
   return (
-    <div className="flex flex-col gap-8">
-      <div className="flex flex-col gap-2">
-        <h1 className="text-3xl font-bold">Explore Courses</h1>
+    <div className="flex flex-col gap-6">
+      {/* Page header */}
+      <div className="flex flex-col gap-1">
+        <h1 className="text-3xl font-bold tracking-tight">Explore Courses</h1>
         <p className="text-muted-foreground">Browse and search from 6,645+ courses</p>
       </div>
-      <div className="flex gap-2">
-        <div className="relative flex-1">
-          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
-          <Input placeholder="Search courses..." className="pl-9" />
+
+      {/* Search bar */}
+      <div className="relative">
+        <Search className="absolute left-3 top-1/2 h-5 w-5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search courses by topic, skill, or keyword..."
+          className="pl-10 h-12 text-base"
+          aria-label="Search courses"
+        />
+      </div>
+
+      {/* Filters */}
+      <SearchFilters
+        level={level}
+        minRating={minRating}
+        onLevelChange={setLevel}
+        onMinRatingChange={setMinRating}
+        onClearFilters={handleClearFilters}
+      />
+
+      {/* AI Summary panel */}
+      {aiSummary && <AiSummaryPanel text={aiSummary} />}
+
+      {/* Error state */}
+      {error && (
+        <div className="flex items-center gap-3 rounded-lg border border-destructive/30 bg-destructive/10 p-4 text-destructive">
+          <AlertCircle className="h-5 w-5 shrink-0" />
+          <div>
+            <p className="font-medium">Search failed</p>
+            <p className="text-sm opacity-80">{error.message}</p>
+          </div>
         </div>
-        <Button>Search</Button>
-      </div>
-      <div className="text-center text-muted-foreground py-12">
-        Search for courses to get started
-      </div>
+      )}
+
+      {/* Result count */}
+      {hasResults && !isLoading && (
+        <p className="text-sm text-muted-foreground">
+          Showing <span className="font-medium text-foreground">{courses.length}</span> of{" "}
+          <span className="font-medium text-foreground">{total.toLocaleString()}</span> results
+          {query && (
+            <>
+              {" "}for{" "}
+              <span className="font-medium text-foreground">&ldquo;{query}&rdquo;</span>
+            </>
+          )}
+        </p>
+      )}
+
+      {/* Course grid — loading skeletons */}
+      {isLoading && courses.length === 0 && (
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: SKELETON_COUNT }).map((_, i) => (
+            <CourseCardSkeleton key={i} />
+          ))}
+        </div>
+      )}
+
+      {/* Course grid — results */}
+      {hasResults && (
+        <>
+          <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+            {courses.map((course) => (
+              <CourseCard key={course.id} course={course} />
+            ))}
+            {/* Inline skeletons when loading more */}
+            {isLoading &&
+              Array.from({ length: 3 }).map((_, i) => <CourseCardSkeleton key={`more-${i}`} />)}
+          </div>
+
+          {/* Load more / pagination */}
+          {hasMore && !isLoading && (
+            <div className="flex justify-center pt-2">
+              <Button
+                variant="outline"
+                onClick={loadMore}
+                className="min-w-[160px]"
+              >
+                Load more courses
+              </Button>
+            </div>
+          )}
+
+          {isLoading && courses.length > 0 && (
+            <div className="flex justify-center pt-2">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          )}
+        </>
+      )}
+
+      {/* Empty state — no results */}
+      {showEmpty && (
+        <div className="flex flex-col items-center gap-3 py-16 text-center text-muted-foreground">
+          <BookOpen className="h-12 w-12 opacity-30" />
+          <p className="text-lg font-medium">No courses found</p>
+          <p className="text-sm max-w-xs">
+            Try a different keyword or adjust your filters.
+          </p>
+          <Button variant="outline" size="sm" onClick={handleClearFilters}>
+            Clear filters
+          </Button>
+        </div>
+      )}
+
+      {/* Initial placeholder — before any search */}
+      {!hasQuery && !isLoading && (
+        <div className="flex flex-col items-center gap-3 py-16 text-center text-muted-foreground">
+          <Search className="h-12 w-12 opacity-30" />
+          <p className="text-lg font-medium">Search for courses</p>
+          <p className="text-sm max-w-xs">
+            Enter a keyword above to discover courses from Coursera&apos;s catalog.
+          </p>
+        </div>
+      )}
     </div>
   )
 }

--- a/frontend/src/features/explore/components/AiSummaryPanel.tsx
+++ b/frontend/src/features/explore/components/AiSummaryPanel.tsx
@@ -1,0 +1,57 @@
+import { useState } from "react"
+import { Sparkles, ChevronDown, ChevronUp } from "lucide-react"
+import { Button } from "@/lib/ui/button"
+import { cn } from "@/lib/utils"
+
+interface AiSummaryPanelProps {
+  text: string
+  isStreaming?: boolean
+}
+
+export function AiSummaryPanel({ text, isStreaming = false }: AiSummaryPanelProps) {
+  const [isCollapsed, setIsCollapsed] = useState(false)
+
+  if (!text && !isStreaming) return null
+
+  return (
+    <div className="rounded-lg border border-primary/20 bg-primary/5 p-4">
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2 text-primary">
+          <Sparkles className="h-4 w-4" />
+          <span className="text-sm font-medium">AI Summary</span>
+        </div>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-6 px-2 text-muted-foreground hover:text-foreground md:hidden"
+          onClick={() => setIsCollapsed((prev) => !prev)}
+          aria-label={isCollapsed ? "Expand summary" : "Collapse summary"}
+        >
+          {isCollapsed ? (
+            <ChevronDown className="h-3.5 w-3.5" />
+          ) : (
+            <ChevronUp className="h-3.5 w-3.5" />
+          )}
+        </Button>
+      </div>
+
+      <div
+        className={cn(
+          "text-sm text-foreground leading-relaxed overflow-hidden transition-all duration-200",
+          isCollapsed ? "max-h-0 md:max-h-none" : "max-h-none"
+        )}
+      >
+        {isStreaming && !text ? (
+          <span className="text-muted-foreground animate-pulse">Generating summary...</span>
+        ) : (
+          <>
+            {text}
+            {isStreaming && (
+              <span className="inline-block w-0.5 h-4 bg-primary ml-0.5 animate-[blink_1s_ease-in-out_infinite]" />
+            )}
+          </>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/explore/components/CourseCard.tsx
+++ b/frontend/src/features/explore/components/CourseCard.tsx
@@ -1,0 +1,106 @@
+import { ExternalLink, Star, Users } from "lucide-react"
+import { Card, CardContent, CardFooter, CardHeader } from "@/lib/ui/card"
+import { Badge } from "@/lib/ui/badge"
+import { Button } from "@/lib/ui/button"
+import { cn } from "@/lib/utils"
+import type { Course } from "@/lib/types/course"
+
+interface CourseCardProps {
+  course: Course
+}
+
+function formatEnrolled(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`
+  return String(count)
+}
+
+function getLevelBadgeClass(level: Course["level"]): string {
+  switch (level) {
+    case "Beginner":
+      return "bg-green-100 text-green-800 border-green-200"
+    case "Intermediate":
+      return "bg-blue-100 text-blue-800 border-blue-200"
+    case "Advanced":
+      return "bg-orange-100 text-orange-800 border-orange-200"
+    default:
+      return "bg-gray-100 text-gray-600 border-gray-200"
+  }
+}
+
+export function CourseCard({ course }: CourseCardProps) {
+  const visibleSkills = course.skills.slice(0, 3)
+  const remainingSkills = course.skills.length - 3
+
+  return (
+    <Card className="flex flex-col h-full transition-shadow hover:shadow-md hover:border-primary/30">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 min-w-0">
+            <h3
+              className="font-semibold text-base leading-snug line-clamp-2 mb-1"
+              title={course.title}
+            >
+              {course.title}
+            </h3>
+            <p className="text-sm text-muted-foreground truncate">{course.organization}</p>
+          </div>
+          {course.level && (
+            <Badge
+              variant="outline"
+              className={cn("shrink-0 text-xs", getLevelBadgeClass(course.level))}
+            >
+              {course.level}
+            </Badge>
+          )}
+        </div>
+      </CardHeader>
+
+      <CardContent className="flex-1 pb-3">
+        <div className="flex items-center gap-3 text-sm text-muted-foreground mb-3">
+          <span className="flex items-center gap-1">
+            <Star className="h-3.5 w-3.5 fill-amber-400 text-amber-400" />
+            <span className="font-medium text-foreground">{course.rating.toFixed(1)}</span>
+          </span>
+          <span className="flex items-center gap-1">
+            <Users className="h-3.5 w-3.5" />
+            <span>{formatEnrolled(course.enrolled)} enrolled</span>
+          </span>
+        </div>
+
+        {visibleSkills.length > 0 && (
+          <div className="flex flex-wrap gap-1">
+            {visibleSkills.map((skill) => (
+              <Badge
+                key={skill}
+                variant="secondary"
+                className="text-xs px-2 py-0.5"
+              >
+                {skill}
+              </Badge>
+            ))}
+            {remainingSkills > 0 && (
+              <Badge variant="outline" className="text-xs px-2 py-0.5 text-muted-foreground">
+                +{remainingSkills} more
+              </Badge>
+            )}
+          </div>
+        )}
+      </CardContent>
+
+      <CardFooter className="pt-0">
+        <Button
+          variant="outline"
+          size="sm"
+          className="w-full gap-1.5"
+          asChild
+        >
+          <a href={course.url} target="_blank" rel="noopener noreferrer">
+            View Course
+            <ExternalLink className="h-3.5 w-3.5" />
+          </a>
+        </Button>
+      </CardFooter>
+    </Card>
+  )
+}

--- a/frontend/src/features/explore/components/CourseCardSkeleton.tsx
+++ b/frontend/src/features/explore/components/CourseCardSkeleton.tsx
@@ -1,0 +1,33 @@
+import { Card, CardContent, CardFooter, CardHeader } from "@/lib/ui/card"
+import { Skeleton } from "@/lib/ui/skeleton"
+
+export function CourseCardSkeleton() {
+  return (
+    <Card className="flex flex-col h-full">
+      <CardHeader className="pb-3">
+        <div className="flex items-start justify-between gap-2">
+          <div className="flex-1 space-y-2">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-3/4" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+          <Skeleton className="h-5 w-20 shrink-0 rounded-full" />
+        </div>
+      </CardHeader>
+      <CardContent className="flex-1 pb-3 space-y-3">
+        <div className="flex gap-3">
+          <Skeleton className="h-3 w-12" />
+          <Skeleton className="h-3 w-24" />
+        </div>
+        <div className="flex gap-1">
+          <Skeleton className="h-5 w-16 rounded-full" />
+          <Skeleton className="h-5 w-20 rounded-full" />
+          <Skeleton className="h-5 w-14 rounded-full" />
+        </div>
+      </CardContent>
+      <CardFooter className="pt-0">
+        <Skeleton className="h-8 w-full rounded-md" />
+      </CardFooter>
+    </Card>
+  )
+}

--- a/frontend/src/features/explore/components/SearchFilters.tsx
+++ b/frontend/src/features/explore/components/SearchFilters.tsx
@@ -1,0 +1,64 @@
+import { X } from "lucide-react"
+import { Button } from "@/lib/ui/button"
+import { Select } from "@/lib/ui/select"
+
+export type LevelFilter = "" | "Beginner" | "Intermediate" | "Advanced"
+export type RatingFilter = "" | "4.0" | "4.5" | "4.7"
+
+interface SearchFiltersProps {
+  level: LevelFilter
+  minRating: RatingFilter
+  onLevelChange: (value: LevelFilter) => void
+  onMinRatingChange: (value: RatingFilter) => void
+  onClearFilters: () => void
+}
+
+export function SearchFilters({
+  level,
+  minRating,
+  onLevelChange,
+  onMinRatingChange,
+  onClearFilters,
+}: SearchFiltersProps) {
+  const hasActiveFilters = level !== "" || minRating !== ""
+
+  return (
+    <div className="flex flex-wrap items-center gap-2">
+      <Select
+        value={level}
+        onChange={(e) => onLevelChange(e.target.value as LevelFilter)}
+        className="w-auto min-w-[140px]"
+        aria-label="Filter by level"
+      >
+        <option value="">All Levels</option>
+        <option value="Beginner">Beginner</option>
+        <option value="Intermediate">Intermediate</option>
+        <option value="Advanced">Advanced</option>
+      </Select>
+
+      <Select
+        value={minRating}
+        onChange={(e) => onMinRatingChange(e.target.value as RatingFilter)}
+        className="w-auto min-w-[140px]"
+        aria-label="Filter by minimum rating"
+      >
+        <option value="">Any Rating</option>
+        <option value="4.0">4.0+ Stars</option>
+        <option value="4.5">4.5+ Stars</option>
+        <option value="4.7">4.7+ Stars</option>
+      </Select>
+
+      {hasActiveFilters && (
+        <Button
+          variant="ghost"
+          size="sm"
+          onClick={onClearFilters}
+          className="gap-1.5 text-muted-foreground hover:text-foreground"
+        >
+          <X className="h-3.5 w-3.5" />
+          Clear filters
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/features/explore/hooks/useCourseSearch.ts
+++ b/frontend/src/features/explore/hooks/useCourseSearch.ts
@@ -1,0 +1,136 @@
+import { useState, useEffect, useCallback, useRef } from "react"
+import type { Course, CourseSearchResult } from "@/lib/types/course"
+import { useDebounce } from "@/lib/hooks/useDebounce"
+import type { ApiError } from "@/lib/types/api"
+
+const API_BASE_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3001"
+const LIMIT = 12
+
+interface UseCourseSearchParams {
+  query: string
+  level?: string
+  minRating?: string
+}
+
+interface UseCourseSearchReturn {
+  courses: Course[]
+  total: number
+  aiSummary: string | undefined
+  isLoading: boolean
+  error: ApiError | null
+  offset: number
+  hasMore: boolean
+  loadMore: () => void
+  reset: () => void
+}
+
+export function useCourseSearch({
+  query,
+  level,
+  minRating,
+}: UseCourseSearchParams): UseCourseSearchReturn {
+  const debouncedQuery = useDebounce(query, 300)
+
+  const [courses, setCourses] = useState<Course[]>([])
+  const [total, setTotal] = useState(0)
+  const [aiSummary, setAiSummary] = useState<string | undefined>(undefined)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<ApiError | null>(null)
+  const [offset, setOffset] = useState(0)
+
+  // Track the latest fetch to avoid race conditions
+  const fetchIdRef = useRef(0)
+
+  const fetchCourses = useCallback(
+    async (currentOffset: number, append: boolean) => {
+      if (!debouncedQuery.trim()) {
+        setCourses([])
+        setTotal(0)
+        setAiSummary(undefined)
+        setError(null)
+        return
+      }
+
+      const fetchId = ++fetchIdRef.current
+      setIsLoading(true)
+      setError(null)
+
+      try {
+        const params = new URLSearchParams({
+          q: debouncedQuery,
+          limit: String(LIMIT),
+          offset: String(currentOffset),
+        })
+        if (level) params.set("level", level)
+        if (minRating) params.set("min_rating", minRating)
+
+        const response = await fetch(`${API_BASE_URL}/api/courses/search?${params.toString()}`, {
+          headers: { "Content-Type": "application/json" },
+        })
+
+        if (!response.ok) {
+          const errorData = await response.json().catch(() => ({}))
+          throw {
+            message: (errorData as { message?: string }).message ?? "Search failed",
+            code: String(response.status),
+          } as ApiError
+        }
+
+        const data = (await response.json()) as CourseSearchResult
+
+        // Ignore stale responses
+        if (fetchId !== fetchIdRef.current) return
+
+        if (append) {
+          setCourses((prev) => [...prev, ...data.courses])
+        } else {
+          setCourses(data.courses)
+        }
+        setTotal(data.total)
+        setAiSummary(data.ai_summary)
+      } catch (err) {
+        if (fetchId !== fetchIdRef.current) return
+        setError(err as ApiError)
+      } finally {
+        if (fetchId === fetchIdRef.current) {
+          setIsLoading(false)
+        }
+      }
+    },
+    [debouncedQuery, level, minRating]
+  )
+
+  // Reset and re-fetch when query or filters change
+  useEffect(() => {
+    setOffset(0)
+    void fetchCourses(0, false)
+  }, [fetchCourses])
+
+  const loadMore = useCallback(() => {
+    const newOffset = offset + LIMIT
+    setOffset(newOffset)
+    void fetchCourses(newOffset, true)
+  }, [offset, fetchCourses])
+
+  const reset = useCallback(() => {
+    setCourses([])
+    setTotal(0)
+    setAiSummary(undefined)
+    setError(null)
+    setOffset(0)
+  }, [])
+
+  const hasMore = courses.length < total
+
+  return {
+    courses,
+    total,
+    aiSummary,
+    isLoading,
+    error,
+    offset,
+    hasMore,
+    loadMore,
+    reset,
+  }
+}

--- a/frontend/src/lib/ui/select.tsx
+++ b/frontend/src/lib/ui/select.tsx
@@ -1,0 +1,24 @@
+import * as React from "react"
+import { cn } from "@/lib/utils"
+
+export interface SelectProps extends React.SelectHTMLAttributes<HTMLSelectElement> {}
+
+const Select = React.forwardRef<HTMLSelectElement, SelectProps>(
+  ({ className, children, ...props }, ref) => {
+    return (
+      <select
+        ref={ref}
+        className={cn(
+          "flex h-9 w-full rounded-md border border-input bg-background px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50",
+          className
+        )}
+        {...props}
+      >
+        {children}
+      </select>
+    )
+  }
+)
+Select.displayName = "Select"
+
+export { Select }

--- a/frontend/src/lib/ui/skeleton.tsx
+++ b/frontend/src/lib/ui/skeleton.tsx
@@ -1,0 +1,12 @@
+import { cn } from "@/lib/utils"
+
+function Skeleton({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return (
+    <div
+      className={cn("animate-pulse rounded-md bg-muted", className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }


### PR DESCRIPTION
## Summary

- CourseCard コンポーネント（レベルバッジ・評価・スキルタグ）
- SearchFilters コンポーネント（Level / Rating フィルタ）
- AiSummaryPanel コンポーネント（ストリーミング表示対応）
- useCourseSearch フック（デバウンス・ページネーション）
- ExplorePage 全体実装（検索・フィルタ・グリッド・ローディング・空状態・エラー状態）
- Skeleton / Select UI コンポーネント追加

## Test plan

- [ ] 検索バーに入力するとコースカードが表示される
- [ ] Level / Rating フィルタが動作する
- [ ] ローディング中はスケルトンが表示される
- [ ] `bun run typecheck` がパスする

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)