### PR TITLE
feat(frontend): Chat ページ実装（AI 対話 UI）

### DIFF
--- a/frontend/src/features/chat/ChatPage.tsx
+++ b/frontend/src/features/chat/ChatPage.tsx
@@ -1,34 +1,78 @@
-import { useState } from "react"
-import { Send } from "lucide-react"
-import { Input } from "@/lib/ui/input"
+import { useState, useRef, useEffect } from "react"
+import { Trash2 } from "lucide-react"
 import { Button } from "@/lib/ui/button"
+import { ChatMessage } from "./components/ChatMessage"
+import { ChatInput } from "./components/ChatInput"
+import { TypingIndicator } from "./components/TypingIndicator"
+import { SuggestedPrompts } from "./components/SuggestedPrompts"
+import { useChat } from "./hooks/useChat"
 
 export function ChatPage() {
-  const [message, setMessage] = useState("")
+  const [input, setInput] = useState("")
+  const { messages, isLoading, isStreaming, sendMessage, clearChat } = useChat()
+  const bottomRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" })
+  }, [messages, isLoading])
+
+  const handleSubmit = async () => {
+    const text = input.trim()
+    if (!text) return
+    setInput("")
+    await sendMessage(text)
+  }
+
+  const handleSuggest = (text: string) => {
+    setInput(text)
+    sendMessage(text)
+  }
 
   return (
     <div className="flex flex-col h-[calc(100vh-8rem)]">
-      <div className="flex flex-col gap-2 mb-6">
-        <h1 className="text-3xl font-bold">AI Course Assistant</h1>
-        <p className="text-muted-foreground">
-          Ask me anything about courses, skill gaps, or learning paths
-        </p>
-      </div>
-      <div className="flex-1 rounded-lg border bg-muted/20 p-4 overflow-y-auto mb-4">
-        <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
-          <p>Start a conversation to discover the perfect course for you</p>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4 shrink-0">
+        <div>
+          <h1 className="text-2xl font-bold">Chat with Lumineer AI</h1>
+          <p className="text-sm text-muted-foreground">
+            Discover courses, analyze skill gaps, and generate learning paths
+          </p>
         </div>
+        {messages.length > 0 && (
+          <Button variant="ghost" size="sm" onClick={clearChat} className="gap-2 text-muted-foreground">
+            <Trash2 className="h-4 w-4" />
+            Clear
+          </Button>
+        )}
       </div>
-      <div className="flex gap-2">
-        <Input
-          value={message}
-          onChange={(e) => setMessage(e.target.value)}
-          placeholder="Ask about courses, skills, or learning paths..."
-          onKeyDown={(e) => e.key === "Enter" && setMessage("")}
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto rounded-xl border bg-muted/10 p-4">
+        {messages.length === 0 ? (
+          <SuggestedPrompts onSelect={handleSuggest} />
+        ) : (
+          <div className="flex flex-col gap-6">
+            {messages.map((msg) => (
+              <ChatMessage key={msg.id} message={msg} />
+            ))}
+            {isLoading && <TypingIndicator />}
+            <div ref={bottomRef} />
+          </div>
+        )}
+      </div>
+
+      {/* Input */}
+      <div className="mt-3 shrink-0">
+        <ChatInput
+          value={input}
+          onChange={setInput}
+          onSubmit={handleSubmit}
+          disabled={isLoading || isStreaming}
+          isStreaming={isStreaming}
         />
-        <Button size="icon" onClick={() => setMessage("")}>
-          <Send className="h-4 w-4" />
-        </Button>
+        <p className="text-center text-[11px] text-muted-foreground mt-2">
+          Lumineer AI can make mistakes. Verify important information.
+        </p>
       </div>
     </div>
   )

--- a/frontend/src/features/chat/components/ChatInput.tsx
+++ b/frontend/src/features/chat/components/ChatInput.tsx
@@ -1,0 +1,56 @@
+import { useRef, useEffect, KeyboardEvent } from "react"
+import { ArrowUp } from "lucide-react"
+import { Button } from "@/lib/ui/button"
+import { cn } from "@/lib/utils"
+
+interface ChatInputProps {
+  value: string
+  onChange: (value: string) => void
+  onSubmit: () => void
+  disabled?: boolean
+  isStreaming?: boolean
+}
+
+export function ChatInput({ value, onChange, onSubmit, disabled, isStreaming }: ChatInputProps) {
+  const textareaRef = useRef<HTMLTextAreaElement>(null)
+
+  useEffect(() => {
+    const ta = textareaRef.current
+    if (!ta) return
+    ta.style.height = "auto"
+    ta.style.height = `${Math.min(ta.scrollHeight, 128)}px`
+  }, [value])
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault()
+      if (!disabled && value.trim()) onSubmit()
+    }
+  }
+
+  return (
+    <div className="relative flex items-end gap-2 rounded-2xl border bg-background p-2 shadow-sm focus-within:ring-1 focus-within:ring-ring">
+      <textarea
+        ref={textareaRef}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        onKeyDown={handleKeyDown}
+        placeholder={isStreaming ? "AI is thinking..." : "Ask about courses, skills, or learning paths..."}
+        disabled={disabled}
+        rows={1}
+        className={cn(
+          "flex-1 resize-none bg-transparent px-2 py-1 text-sm outline-none placeholder:text-muted-foreground",
+          "min-h-[36px] max-h-32 scrollbar-thin disabled:cursor-not-allowed disabled:opacity-50"
+        )}
+      />
+      <Button
+        size="icon"
+        className="h-8 w-8 shrink-0 rounded-xl"
+        onClick={onSubmit}
+        disabled={disabled || !value.trim()}
+      >
+        <ArrowUp className="h-4 w-4" />
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/features/chat/components/ChatMessage.tsx
+++ b/frontend/src/features/chat/components/ChatMessage.tsx
@@ -1,0 +1,82 @@
+import { Sparkles, User } from "lucide-react"
+import { cn } from "@/lib/utils"
+import { CourseCardMini } from "./CourseCardMini"
+import type { Course } from "@/lib/types/course"
+
+export interface ChatMessageData {
+  id: string
+  role: "user" | "assistant"
+  content: string
+  courses?: Course[]
+  timestamp: Date
+}
+
+interface ChatMessageProps {
+  message: ChatMessageData
+}
+
+function renderContent(text: string) {
+  const parts = text.split(/(\*\*[^*]+\*\*|`[^`]+`)/g)
+  return parts.map((part, i) => {
+    if (part.startsWith("**") && part.endsWith("**")) {
+      return <strong key={i}>{part.slice(2, -2)}</strong>
+    }
+    if (part.startsWith("`") && part.endsWith("`")) {
+      return (
+        <code key={i} className="rounded bg-muted px-1 py-0.5 text-xs font-mono">
+          {part.slice(1, -1)}
+        </code>
+      )
+    }
+    return <span key={i}>{part}</span>
+  })
+}
+
+export function ChatMessage({ message }: ChatMessageProps) {
+  const isUser = message.role === "user"
+
+  return (
+    <div className={cn("flex items-start gap-3", isUser && "flex-row-reverse")}>
+      {/* Avatar */}
+      <div
+        className={cn(
+          "flex h-8 w-8 shrink-0 items-center justify-center rounded-full",
+          isUser ? "bg-primary text-primary-foreground" : "bg-primary/10"
+        )}
+      >
+        {isUser ? (
+          <User className="h-4 w-4" />
+        ) : (
+          <Sparkles className="h-4 w-4 text-primary" />
+        )}
+      </div>
+
+      {/* Bubble */}
+      <div className={cn("flex flex-col gap-2 max-w-[80%]", isUser && "items-end")}>
+        <div
+          className={cn(
+            "rounded-2xl px-4 py-3 text-sm leading-relaxed",
+            isUser
+              ? "rounded-tr-sm bg-primary text-primary-foreground"
+              : "rounded-tl-sm bg-muted text-foreground"
+          )}
+        >
+          {renderContent(message.content)}
+        </div>
+
+        {/* Inline course cards */}
+        {message.courses && message.courses.length > 0 && (
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 w-full">
+            {message.courses.map((course) => (
+              <CourseCardMini key={course.id} course={course} />
+            ))}
+          </div>
+        )}
+
+        <span className="text-[10px] text-muted-foreground px-1">
+          {message.timestamp.toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}
+        </span>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/chat/components/CourseCardMini.tsx
+++ b/frontend/src/features/chat/components/CourseCardMini.tsx
@@ -1,0 +1,46 @@
+import { ExternalLink, Star } from "lucide-react"
+
+import { Button } from "@/lib/ui/button"
+import type { Course } from "@/lib/types/course"
+
+const levelVariant: Record<string, string> = {
+  Beginner: "bg-emerald-100 text-emerald-700",
+  Intermediate: "bg-blue-100 text-blue-700",
+  Advanced: "bg-orange-100 text-orange-700",
+}
+
+interface CourseCardMiniProps {
+  course: Course
+}
+
+export function CourseCardMini({ course }: CourseCardMiniProps) {
+  const formatEnrolled = (n: number) =>
+    n >= 1000 ? `${(n / 1000).toFixed(1)}k` : String(n)
+
+  return (
+    <div className="flex items-center gap-3 rounded-lg border bg-background p-3 hover:bg-muted/30 transition-colors">
+      <div className="flex-1 min-w-0">
+        <p className="font-medium text-sm leading-tight line-clamp-1">{course.title}</p>
+        <p className="text-xs text-muted-foreground mt-0.5">{course.organization}</p>
+        <div className="flex items-center gap-2 mt-1 flex-wrap">
+          {course.level && (
+            <span className={`text-[10px] font-medium px-1.5 py-0.5 rounded-full ${levelVariant[course.level] ?? "bg-gray-100 text-gray-700"}`}>
+              {course.level}
+            </span>
+          )}
+          <span className="flex items-center gap-0.5 text-xs text-amber-500">
+            <Star className="h-3 w-3 fill-current" />
+            {course.rating.toFixed(1)}
+          </span>
+          <span className="text-xs text-muted-foreground">{formatEnrolled(course.enrolled)} enrolled</span>
+        </div>
+      </div>
+      <Button asChild variant="ghost" size="sm" className="shrink-0 h-7 px-2 text-xs">
+        <a href={course.url} target="_blank" rel="noopener noreferrer">
+          <ExternalLink className="h-3 w-3 mr-1" />
+          View
+        </a>
+      </Button>
+    </div>
+  )
+}

--- a/frontend/src/features/chat/components/SuggestedPrompts.tsx
+++ b/frontend/src/features/chat/components/SuggestedPrompts.tsx
@@ -1,0 +1,39 @@
+import { Search, Target, Map, BookOpen } from "lucide-react"
+import { Button } from "@/lib/ui/button"
+
+const prompts = [
+  { icon: Search, text: "Find Python courses for beginners" },
+  { icon: Target, text: "Analyze my skill gap for data science" },
+  { icon: Map, text: "Create a 3-month web dev learning path" },
+  { icon: BookOpen, text: "Top machine learning courses" },
+]
+
+interface SuggestedPromptsProps {
+  onSelect: (text: string) => void
+}
+
+export function SuggestedPrompts({ onSelect }: SuggestedPromptsProps) {
+  return (
+    <div className="flex flex-col items-center gap-6 py-12">
+      <div className="text-center">
+        <h2 className="text-xl font-semibold">How can I help you today?</h2>
+        <p className="text-sm text-muted-foreground mt-1">
+          Ask me about courses, skill gaps, or learning paths
+        </p>
+      </div>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3 w-full max-w-xl">
+        {prompts.map(({ icon: Icon, text }) => (
+          <Button
+            key={text}
+            variant="outline"
+            className="h-auto py-3 px-4 justify-start gap-3 text-left hover:border-primary/50 hover:bg-primary/5"
+            onClick={() => onSelect(text)}
+          >
+            <Icon className="h-4 w-4 shrink-0 text-primary" />
+            <span className="text-sm">{text}</span>
+          </Button>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/chat/components/TypingIndicator.tsx
+++ b/frontend/src/features/chat/components/TypingIndicator.tsx
@@ -1,0 +1,16 @@
+import { Sparkles } from "lucide-react"
+
+export function TypingIndicator() {
+  return (
+    <div className="flex items-start gap-3">
+      <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-full bg-primary/10">
+        <Sparkles className="h-4 w-4 text-primary" />
+      </div>
+      <div className="flex items-center gap-1 rounded-2xl rounded-tl-sm bg-muted px-4 py-3">
+        <span className="h-2 w-2 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:0ms]" />
+        <span className="h-2 w-2 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:150ms]" />
+        <span className="h-2 w-2 rounded-full bg-muted-foreground/50 animate-bounce [animation-delay:300ms]" />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/features/chat/hooks/useChat.ts
+++ b/frontend/src/features/chat/hooks/useChat.ts
@@ -1,0 +1,130 @@
+import { useState, useRef, useCallback } from "react"
+import type { ChatMessageData } from "../components/ChatMessage"
+import type { Course } from "@/lib/types/course"
+
+const API_URL = import.meta.env.VITE_API_URL ?? "http://localhost:3001"
+
+function generateId() {
+  return Math.random().toString(36).slice(2)
+}
+
+export function useChat() {
+  const [messages, setMessages] = useState<ChatMessageData[]>([])
+  const [isLoading, setIsLoading] = useState(false)
+  const [isStreaming, setIsStreaming] = useState(false)
+  const abortRef = useRef<AbortController | null>(null)
+
+  const sendMessage = useCallback(async (text: string) => {
+    if (!text.trim() || isLoading || isStreaming) return
+
+    const userMessage: ChatMessageData = {
+      id: generateId(),
+      role: "user",
+      content: text.trim(),
+      timestamp: new Date(),
+    }
+
+    const assistantId = generateId()
+    const assistantMessage: ChatMessageData = {
+      id: assistantId,
+      role: "assistant",
+      content: "",
+      timestamp: new Date(),
+    }
+
+    setMessages((prev) => [...prev, userMessage, assistantMessage])
+    setIsLoading(true)
+
+    abortRef.current?.abort()
+    const controller = new AbortController()
+    abortRef.current = controller
+
+    try {
+      const res = await fetch(`${API_URL}/api/chat`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ message: text.trim() }),
+        signal: controller.signal,
+      })
+
+      if (!res.ok || !res.body) {
+        throw new Error(`HTTP ${res.status}`)
+      }
+
+      setIsLoading(false)
+      setIsStreaming(true)
+
+      const reader = res.body.getReader()
+      const decoder = new TextDecoder()
+      let buffer = ""
+
+      while (true) {
+        const { value, done } = await reader.read()
+        if (done) break
+
+        buffer += decoder.decode(value, { stream: true })
+        const lines = buffer.split("\n")
+        buffer = lines.pop() ?? ""
+
+        for (const line of lines) {
+          if (!line.startsWith("data: ")) continue
+          const raw = line.slice(6).trim()
+          if (!raw || raw === "[DONE]") continue
+
+          try {
+            const event = JSON.parse(raw) as {
+              type: "text" | "courses" | "done"
+              content?: string
+              courses?: Course[]
+            }
+
+            if (event.type === "text" && event.content) {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId
+                    ? { ...m, content: m.content + event.content }
+                    : m
+                )
+              )
+            } else if (event.type === "courses" && event.courses) {
+              setMessages((prev) =>
+                prev.map((m) =>
+                  m.id === assistantId ? { ...m, courses: event.courses } : m
+                )
+              )
+            } else if (event.type === "done") {
+              break
+            }
+          } catch {
+            // skip malformed SSE lines
+          }
+        }
+      }
+    } catch (err) {
+      if ((err as Error).name === "AbortError") return
+
+      setMessages((prev) =>
+        prev.map((m) =>
+          m.id === assistantId
+            ? {
+                ...m,
+                content: m.content || "Sorry, something went wrong. Please try again.",
+              }
+            : m
+        )
+      )
+    } finally {
+      setIsLoading(false)
+      setIsStreaming(false)
+    }
+  }, [isLoading, isStreaming])
+
+  const clearChat = useCallback(() => {
+    abortRef.current?.abort()
+    setMessages([])
+    setIsLoading(false)
+    setIsStreaming(false)
+  }, [])
+
+  return { messages, isLoading, isStreaming, sendMessage, clearChat }
+}


### PR DESCRIPTION
## Summary

- ChatMessage コンポーネント（ユーザー/AI バブル、インラインコースカード、基本マークダウン）
- CourseCardMini コンポーネント（チャット内インライン表示用コンパクトカード）
- ChatInput コンポーネント（Textarea自動リサイズ、Enter送信、Shift+Enter改行）
- TypingIndicator コンポーネント（バウンスアニメーション）
- SuggestedPrompts コンポーネント（初期表示の4つのプロンプト候補）
- useChat フック（SSEストリーミング、会話管理）
- ChatPage フル実装（全コンポーネント統合）

## Test plan

- [ ] メッセージを送るとAIが応答する
- [ ] SuggestedPromptsのチップをクリックするとメッセージが送信される
- [ ] ストリーミング中はTypingIndicatorが表示される
- [ ] Clearボタンで会話がリセットされる
- [ ] `bun run typecheck` がパスする

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)