### PR TITLE
docs(infra): develop への直接コミット禁止ルールを明記

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -25,7 +25,8 @@ LM{IssueID}-{type}/{scope}-{detail}
 hotfix: main → hotfix branch → PR → main + develop マージ
 ```
 
-- main への直接 push 禁止
+- **main への直接 push 禁止**
+- **develop への直接コミット禁止** — どんな小さな変更（ドキュメント修正含む）でも必ず feature branch → PR 経由でマージする。直接コミットすると origin/develop と分岐して他ブランチに影響する
 - feature branch は develop から分岐
 
 ## PR 規約

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,6 +43,7 @@ docker compose up
   - scope: frontend / backend / rag / agents / data / infra / mcp
   - 例: `LM0001-feature/rag-hybrid_search`
 - **Flow**: develop → feature branch → PR → CI → develop → main
+- **develop / main への直接コミット禁止**: どんな小さな変更（docs 修正含む）でも必ず feature branch → PR 経由。直接コミットすると origin と分岐し他ブランチに波及する
 - **PR**: `Closes #{IssueID}` で Issue 自動クローズ
 - **Commit**: 日本語 OK、簡潔に
 


### PR DESCRIPTION
## Summary

- CLAUDE.md と .claude/rules/workflow.md に develop/main への直接コミット禁止ルールを追記
- どんな小さな変更（ドキュメント修正含む）でも必ず feature branch → PR 経由でマージすること

## 背景

develop に直接コミットしてしまい origin/develop と分岐が発生した。再発防止のためルールを明文化。

🤖 Generated with [Claude Code](https://claude.com/claude-code)