### PR TITLE
docs(infra): ワークフロールール強化

### DIFF
--- a/.claude/rules/workflow.md
+++ b/.claude/rules/workflow.md
@@ -26,6 +26,7 @@ hotfix: main → hotfix branch → PR → main + develop マージ
 ```
 
 - main への直接 push 禁止
+- **develop への直接コミット禁止**: 全ての変更は feature branch → PR 経由でマージする
 - feature branch は develop から分岐
 
 ## PR 規約
@@ -40,9 +41,15 @@ hotfix: main → hotfix branch → PR → main + develop マージ
 - 1コミット = 1つの論理的変更
 - API Key やシークレットを含むコミットは禁止
 
-## 並列開発: git worktree
+## 鉄則: Issue 先行 + worktree 必須
 
-複数 Issue を同時並行で進める場合は `git worktree` を使用する。
+1. **Issue 先行**: ブランチ作成前に必ず GitHub Issue を立て、その Issue 番号をブランチ名に使用する。無関係なタスクに既存 Issue の番号を流用しない
+2. **メインリポジトリは常に develop**: メインリポジトリで `git checkout` して他ブランチに切り替えない。feature 作業は必ず `git worktree` で行う
+3. **develop への直接コミット禁止**: どんな小さな変更でも feature branch → PR 経由
+
+## git worktree（必須）
+
+全ての feature 作業は `git worktree` を使用する。
 
 ### worktree の格納場所
 


### PR DESCRIPTION
## Summary

- develop への直接コミント禁止を明記
- メインリポジトリは常に develop ブランチのまま維持、feature 作業は必ず worktree を使用
- Issue 先行ルールを明記（ブランチ作成前に必ず Issue を立てる、番号流用禁止）

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)