### PR TITLE
fix(infra): gh-task.sh を worktree 対応に修正

### DIFF
--- a/scripts/gh-task.sh
+++ b/scripts/gh-task.sh
@@ -124,7 +124,8 @@ PADDED_NUM="$(printf '%04d' "$ISSUE_NUM")"
 BRANCH_NAME="LM${PADDED_NUM}-${TASK_TYPE}/${TASK_SCOPE}-${BR_DETAIL}"
 # ブランチ名の / を - に置換してディレクトリ名にする
 WORKTREE_DIR="$(echo "${BRANCH_NAME}" | tr '/' '-')"
-REPO_ROOT="$(git rev-parse --show-toplevel)"
+# worktree 内から実行された場合でも main リポジトリのルートを取得する
+REPO_ROOT="$(git worktree list --porcelain | awk 'NR==1{print $2}')"
 WORKTREE_PATH="${REPO_ROOT}/../worktree/${WORKTREE_DIR}"
 
 echo "worktree を作成中: ${BRANCH_NAME}" >&2


### PR DESCRIPTION
## Summary

- `LABEL_ARGS` 空配列の `unbound variable` エラーを修正（`set -u` 環境で VS Code タスクが終了していた）
- `git checkout -b` → `git worktree add` に変更し、ワークフロールール（develop 直接コミット禁止・worktree 必須）に準拠
- 未コミット変更チェックを削除（worktree では現在のブランチを変えないため不要）
- 完了メッセージに worktree パスと `cd` コマンドを追加

## Test plan

- [ ] VS Code タスクから `gh-task.sh` を実行して Issue + worktree が作成されることを確認
- [ ] ラベルなしのリポジトリでも `LABEL_ARGS` エラーが出ないことを確認
- [ ] 作成された worktree が `../worktree/{branch-name-with-dashes}/` に配置されることを確認

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)