### PR TITLE
feat(rag): RAG検索パイプライン実装

### DIFF
--- a/ai/app/config/container.py
+++ b/ai/app/config/container.py
@@ -1,4 +1,5 @@
 """Dependency injection container."""
+
 from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
@@ -30,21 +31,24 @@ class Container:
         """Return the registered VectorStorePort implementation."""
         from app.domain.ports.vector_store import VectorStorePort
 
-        return self.resolve(VectorStorePort)  # type: ignore[return-value]
+        result: VectorStorePort = self.resolve(VectorStorePort)
+        return result
 
     @property
     def embedding(self) -> EmbeddingPort:
         """Return the registered EmbeddingPort implementation."""
         from app.domain.ports.embedding import EmbeddingPort
 
-        return self.resolve(EmbeddingPort)  # type: ignore[return-value]
+        result: EmbeddingPort = self.resolve(EmbeddingPort)
+        return result
 
     @property
     def llm(self) -> LLMPort:
         """Return the registered LLMPort implementation."""
         from app.domain.ports.llm import LLMPort
 
-        return self.resolve(LLMPort)  # type: ignore[return-value]
+        result: LLMPort = self.resolve(LLMPort)
+        return result
 
 
 _container: Container | None = None
@@ -56,3 +60,34 @@ def get_container() -> Container:
     if _container is None:
         _container = Container()
     return _container
+
+
+def build_container() -> Container:
+    """Wire up all ports with their concrete implementations."""
+    from app.config.settings import get_settings
+    from app.domain.ports.embedding import EmbeddingPort
+    from app.domain.ports.vector_store import VectorStorePort
+    from app.infrastructure.embeddings.openai_embedding_adapter import OpenAIEmbeddingAdapter
+    from app.infrastructure.vectordb.qdrant_search_adapter import QdrantSearchAdapter
+
+    settings = get_settings()
+    container = get_container()
+
+    container.register(
+        EmbeddingPort,
+        OpenAIEmbeddingAdapter(
+            api_key=settings.OPENAI_API_KEY,
+            model=settings.EMBEDDING_MODEL,
+            dimensions=settings.EMBEDDING_DIMENSIONS,
+        ),
+    )
+    container.register(
+        VectorStorePort,
+        QdrantSearchAdapter(
+            url=settings.QDRANT_URL,
+            collection_name=settings.QDRANT_COLLECTION,
+            api_key=settings.QDRANT_API_KEY,
+        ),
+    )
+
+    return container

--- a/ai/app/domain/usecases/search_courses.py
+++ b/ai/app/domain/usecases/search_courses.py
@@ -1,0 +1,159 @@
+"""SearchCoursesUseCase: orchestrates the RAG search pipeline."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+from app.domain.entities.course import CourseEntity, CourseFactory
+from app.domain.ports.embedding import EmbeddingPort
+from app.domain.ports.vector_store import VectorStorePort
+from app.infrastructure.formatters.base import BaseFormatter
+from app.infrastructure.reranking.base import BaseReranker
+
+logger = logging.getLogger(__name__)
+
+# Denial-of-Wallet protection: max corrective-RAG retries
+MAX_CORRECTIVE_RETRIES = 2
+
+
+@dataclass
+class SearchQuery:
+    """Input parameters for a course search request."""
+
+    query: str
+    level: str | None = None
+    organization: str | None = None
+    min_rating: float | None = None
+    skills: list[str] | None = None
+    limit: int = 10
+    threshold: float = 0.7
+    prefetch_limit: int = 20
+
+
+@dataclass
+class SearchResult:
+    """Output of a successful search."""
+
+    courses: list[CourseEntity]
+    formatted_context: str
+    total_hits: int
+    reranker_applied: str
+    formatter_applied: str
+
+
+def _payload_to_entity(payload: dict[str, Any]) -> CourseEntity:
+    """Convert a Qdrant payload dict to a CourseEntity."""
+    return CourseFactory.create(
+        id=payload.get("_id"),
+        title=payload.get("title", ""),
+        description=payload.get("description", ""),
+        skills=payload.get("skills") or [],
+        level=payload.get("level"),
+        organization=payload.get("organization", ""),
+        rating=float(payload.get("rating", 0.0)),
+        enrolled=int(payload.get("enrolled", 0)),
+        num_reviews=payload.get("num_reviews"),
+        modules=payload.get("modules"),
+        schedule=payload.get("schedule"),
+        url=payload.get("url", ""),
+        instructor=payload.get("instructor"),
+        search_text="",
+    )
+
+
+class SearchCoursesUseCase:
+    """
+    RAG search pipeline:
+      Embed → Hybrid Search → Threshold filter → Rerank → Format
+
+    Corrective RAG: if results fall below threshold, broaden the query
+    by stripping metadata filters and retrying (up to MAX_CORRECTIVE_RETRIES).
+    """
+
+    def __init__(
+        self,
+        vector_store: VectorStorePort,
+        embedding: EmbeddingPort,
+        reranker: BaseReranker,
+        formatter: BaseFormatter,
+    ) -> None:
+        self._vector_store = vector_store
+        self._embedding = embedding
+        self._reranker = reranker
+        self._formatter = formatter
+
+    async def execute(self, query: SearchQuery) -> SearchResult:
+        filters: dict[str, Any] = {}
+        if query.level:
+            filters["level"] = query.level
+        if query.organization:
+            filters["organization"] = query.organization
+        if query.min_rating is not None:
+            filters["min_rating"] = query.min_rating
+        if query.skills:
+            filters["skills"] = query.skills
+
+        courses = await self._search_with_corrective_rag(query, filters)
+        formatted = self._formatter.format(courses)
+
+        return SearchResult(
+            courses=courses,
+            formatted_context=formatted,
+            total_hits=len(courses),
+            reranker_applied=type(self._reranker).__name__,
+            formatter_applied=type(self._formatter).__name__,
+        )
+
+    async def _search_with_corrective_rag(
+        self,
+        query: SearchQuery,
+        filters: dict[str, Any],
+    ) -> list[CourseEntity]:
+        """Search with optional corrective RAG when results are too few."""
+        query_vector = await self._embedding.embed(query.query)
+        hits: list[dict[str, Any]] = []
+
+        for attempt in range(MAX_CORRECTIVE_RETRIES + 1):
+            raw = await self._vector_store.hybrid_search(
+                query_vector=query_vector,
+                query_text=query.query,
+                limit=query.prefetch_limit,
+                filters=filters if filters else None,
+            )
+
+            above_threshold = [r for r in raw if float(r.get("_score", 0.0)) >= query.threshold]
+
+            if above_threshold or attempt == MAX_CORRECTIVE_RETRIES:
+                hits = above_threshold or raw  # fallback: use all if nothing passes threshold
+                break
+
+            logger.info(
+                "Corrective RAG attempt %d: 0 results above threshold %.2f, relaxing filters",
+                attempt + 1,
+                query.threshold,
+            )
+            filters = {}  # broaden: drop all metadata filters
+
+        # Build entity list preserving Qdrant order
+        entities = [_payload_to_entity(h) for h in hits]
+
+        # Rerank using raw dicts so rerankers can access _score / rating / enrolled
+        reranked_raw = self._reranker.rerank(
+            query=query.query,
+            results=hits,
+            top_k=query.limit,
+        )
+
+        # Map reranked raw dicts back to entities by _id
+        id_to_entity = {e.id: e for e in entities}
+        reranked_entities = [
+            id_to_entity[rr["_id"]] for rr in reranked_raw if rr.get("_id") in id_to_entity
+        ]
+
+        # Fallback if ID mapping fails (should not happen in practice)
+        if not reranked_entities:
+            reranked_entities = entities
+
+        return reranked_entities[: query.limit]

--- a/ai/app/infrastructure/embeddings/openai_embedding_adapter.py
+++ b/ai/app/infrastructure/embeddings/openai_embedding_adapter.py
@@ -1,0 +1,43 @@
+"""OpenAI EmbeddingPort adapter (class-based, for runtime use)."""
+
+import logging
+
+from openai import AsyncOpenAI
+
+from app.domain.ports.embedding import EmbeddingPort
+
+logger = logging.getLogger(__name__)
+
+
+class OpenAIEmbeddingAdapter(EmbeddingPort):
+    """Implements EmbeddingPort using OpenAI text-embedding-3-large."""
+
+    def __init__(
+        self,
+        api_key: str,
+        model: str = "text-embedding-3-large",
+        dimensions: int = 3072,
+    ) -> None:
+        self._client = AsyncOpenAI(api_key=api_key)
+        self._model = model
+        self._dimensions = dimensions
+
+    async def embed(self, text: str) -> list[float]:
+        """Generate a single embedding vector."""
+        sanitized = text.strip() or "."
+        response = await self._client.embeddings.create(
+            input=[sanitized],
+            model=self._model,
+            dimensions=self._dimensions,
+        )
+        return response.data[0].embedding
+
+    async def embed_batch(self, texts: list[str]) -> list[list[float]]:
+        """Generate embedding vectors for a batch of texts."""
+        sanitized = [t.strip() or "." for t in texts]
+        response = await self._client.embeddings.create(
+            input=sanitized,
+            model=self._model,
+            dimensions=self._dimensions,
+        )
+        return [item.embedding for item in response.data]

--- a/ai/app/infrastructure/formatters/__init__.py
+++ b/ai/app/infrastructure/formatters/__init__.py
@@ -1,1 +1,18 @@
-"""Context formatter implementations."""
+"""Context formatter strategy implementations."""
+
+from app.infrastructure.formatters.base import BaseFormatter
+from app.infrastructure.formatters.json_formatter import JsonFormatter
+from app.infrastructure.formatters.toon_formatter import ToonFormatter
+
+__all__ = ["BaseFormatter", "JsonFormatter", "ToonFormatter"]
+
+
+def create_formatter(fmt: str) -> BaseFormatter:
+    """Factory: create formatter from format name ('json' | 'toon')."""
+    match fmt:
+        case "json":
+            return JsonFormatter()
+        case "toon":
+            return ToonFormatter()
+        case _:
+            raise ValueError(f"Unknown formatter: {fmt!r}")

--- a/ai/app/infrastructure/formatters/base.py
+++ b/ai/app/infrastructure/formatters/base.py
@@ -1,0 +1,14 @@
+"""Base interface for context formatters."""
+
+from abc import ABC, abstractmethod
+
+from app.domain.entities.course import CourseEntity
+
+
+class BaseFormatter(ABC):
+    """Strategy interface for formatting search results as LLM context."""
+
+    @abstractmethod
+    def format(self, courses: list[CourseEntity]) -> str:
+        """Format a list of courses into a string for LLM context."""
+        ...

--- a/ai/app/infrastructure/formatters/json_formatter.py
+++ b/ai/app/infrastructure/formatters/json_formatter.py
@@ -1,0 +1,28 @@
+"""JsonFormatter: serialize courses as JSON for LLM context."""
+
+import json
+
+from app.domain.entities.course import CourseEntity
+from app.infrastructure.formatters.base import BaseFormatter
+
+
+class JsonFormatter(BaseFormatter):
+    """Formats courses as a JSON array string."""
+
+    def format(self, courses: list[CourseEntity]) -> str:
+        items = [
+            {
+                "title": c.title,
+                "organization": c.organization,
+                "level": c.level,
+                "rating": c.rating,
+                "enrolled": c.enrolled,
+                "skills": c.skills,
+                "description": c.description,
+                "url": c.url,
+                "schedule": c.schedule,
+                "instructor": c.instructor,
+            }
+            for c in courses
+        ]
+        return json.dumps({"courses": items}, ensure_ascii=False)

--- a/ai/app/infrastructure/formatters/toon_formatter.py
+++ b/ai/app/infrastructure/formatters/toon_formatter.py
@@ -1,0 +1,43 @@
+"""ToonFormatter: Token-Oriented Object Notation — ~50% fewer tokens than JSON.
+
+Format example:
+    courses[3]{title,org,level,rating,enrolled,skills}:
+      ML Specialization,Stanford,Beginner,4.8,12345,"Python, TensorFlow"
+      ...
+"""
+
+from app.domain.entities.course import CourseEntity
+from app.infrastructure.formatters.base import BaseFormatter
+
+_FIELDS = ("title", "org", "level", "rating", "enrolled", "skills")
+
+
+def _escape(value: str) -> str:
+    """Wrap in quotes if the value contains a comma."""
+    return f'"{value}"' if "," in value else value
+
+
+class ToonFormatter(BaseFormatter):
+    """TOON format: one header row, one CSV-like data row per course."""
+
+    def format(self, courses: list[CourseEntity]) -> str:
+        if not courses:
+            return "courses[0]{}: (no results)"
+
+        header = f"courses[{len(courses)}]{{{','.join(_FIELDS)}}}:"
+        rows = []
+        for c in courses:
+            skills_str = _escape(", ".join(c.skills) if c.skills else "")
+            row = ",".join(
+                [
+                    _escape(c.title),
+                    _escape(c.organization),
+                    c.level or "None",
+                    str(round(c.rating, 1)),
+                    str(c.enrolled),
+                    skills_str,
+                ]
+            )
+            rows.append(f"  {row}")
+
+        return "\n".join([header] + rows)

--- a/ai/app/infrastructure/reranking/__init__.py
+++ b/ai/app/infrastructure/reranking/__init__.py
@@ -1,1 +1,21 @@
 """Reranking strategy implementations."""
+
+from app.infrastructure.reranking.base import BaseReranker
+from app.infrastructure.reranking.cross_encoder_reranker import CrossEncoderReranker
+from app.infrastructure.reranking.heuristic_reranker import HeuristicReranker
+from app.infrastructure.reranking.no_reranker import NoReranker
+
+__all__ = ["BaseReranker", "NoReranker", "HeuristicReranker", "CrossEncoderReranker"]
+
+
+def create_reranker(strategy: str) -> BaseReranker:
+    """Factory: create reranker from strategy name."""
+    match strategy:
+        case "none":
+            return NoReranker()
+        case "heuristic":
+            return HeuristicReranker()
+        case "cross-encoder":
+            return CrossEncoderReranker()
+        case _:
+            raise ValueError(f"Unknown reranker strategy: {strategy!r}")

--- a/ai/app/infrastructure/reranking/base.py
+++ b/ai/app/infrastructure/reranking/base.py
@@ -1,0 +1,18 @@
+"""Base interface for all reranker strategies."""
+
+from abc import ABC, abstractmethod
+from typing import Any
+
+
+class BaseReranker(ABC):
+    """Strategy interface for result reranking."""
+
+    @abstractmethod
+    def rerank(
+        self,
+        query: str,
+        results: list[dict[str, Any]],
+        top_k: int,
+    ) -> list[dict[str, Any]]:
+        """Rerank search results and return the top_k entries."""
+        ...

--- a/ai/app/infrastructure/reranking/cross_encoder_reranker.py
+++ b/ai/app/infrastructure/reranking/cross_encoder_reranker.py
@@ -1,0 +1,52 @@
+"""CrossEncoderReranker: neural re-ranking via sentence-transformers."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from app.infrastructure.reranking.base import BaseReranker
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MODEL = "cross-encoder/ms-marco-MiniLM-L-6-v2"
+
+
+class CrossEncoderReranker(BaseReranker):
+    """Reranks using a CrossEncoder model (sentence-transformers).
+
+    Requires: pip install sentence-transformers
+    Adds ~200-500ms latency on CPU for top-20 candidates.
+    """
+
+    def __init__(self, model_name: str = DEFAULT_MODEL) -> None:
+        try:
+            from sentence_transformers import CrossEncoder
+
+            self._model: Any = CrossEncoder(model_name)
+            logger.info("CrossEncoderReranker loaded model: %s", model_name)
+        except ImportError as e:
+            raise ImportError(
+                "sentence-transformers is required for CrossEncoderReranker. "
+                "Install it with: pip install sentence-transformers"
+            ) from e
+
+    def rerank(
+        self,
+        query: str,
+        results: list[dict[str, Any]],
+        top_k: int,
+    ) -> list[dict[str, Any]]:
+        if not results:
+            return []
+
+        passages = [r.get("title", "") + " " + r.get("description", "") for r in results]
+        pairs = [(query, p) for p in passages]
+        raw_scores: list[float] = self._model.predict(pairs).tolist()
+
+        ranked = sorted(
+            zip(raw_scores, results),
+            key=lambda x: x[0],
+            reverse=True,
+        )
+        return [r for _, r in ranked[:top_k]]

--- a/ai/app/infrastructure/reranking/heuristic_reranker.py
+++ b/ai/app/infrastructure/reranking/heuristic_reranker.py
@@ -1,0 +1,41 @@
+"""HeuristicReranker: weighted score combining relevance, rating, and enrolled."""
+
+import math
+from typing import Any
+
+from app.infrastructure.reranking.base import BaseReranker
+
+# Weights for the composite score
+ALPHA = 0.6  # relevance (RRF score, normalized)
+BETA = 0.3  # rating (0-5 → normalized to 0-1)
+GAMMA = 0.1  # enrolled (log-normalized)
+
+MAX_RATING = 5.0
+LOG_ENROLLED_SCALE = 14.0  # ln(1_200_000) ≈ 14 (rough upper bound)
+
+
+class HeuristicReranker(BaseReranker):
+    """Reranks by: α × relevance + β × (rating/5) + γ × ln(enrolled+1)/scale."""
+
+    def rerank(
+        self,
+        query: str,
+        results: list[dict[str, Any]],
+        top_k: int,
+    ) -> list[dict[str, Any]]:
+        if not results:
+            return []
+
+        scores = [float(r.get("_score", 0.0)) for r in results]
+        max_score = max(scores)
+        min_score = min(scores)
+        score_range = max_score - min_score or 1.0
+
+        def composite(r: dict[str, Any]) -> float:
+            relevance = (float(r.get("_score", 0.0)) - min_score) / score_range
+            rating = min(float(r.get("rating", 0.0)), MAX_RATING) / MAX_RATING
+            enrolled = math.log1p(float(r.get("enrolled", 0))) / LOG_ENROLLED_SCALE
+            return ALPHA * relevance + BETA * rating + GAMMA * enrolled
+
+        ranked = sorted(results, key=composite, reverse=True)
+        return ranked[:top_k]

--- a/ai/app/infrastructure/reranking/no_reranker.py
+++ b/ai/app/infrastructure/reranking/no_reranker.py
@@ -1,0 +1,17 @@
+"""NoReranker: pass-through strategy (baseline)."""
+
+from typing import Any
+
+from app.infrastructure.reranking.base import BaseReranker
+
+
+class NoReranker(BaseReranker):
+    """Returns results as-is (RRF order from Qdrant)."""
+
+    def rerank(
+        self,
+        query: str,
+        results: list[dict[str, Any]],
+        top_k: int,
+    ) -> list[dict[str, Any]]:
+        return results[:top_k]

--- a/ai/app/infrastructure/vectordb/qdrant_search_adapter.py
+++ b/ai/app/infrastructure/vectordb/qdrant_search_adapter.py
@@ -1,0 +1,143 @@
+"""Qdrant VectorStorePort adapter: Hybrid Search with RRF."""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastembed.sparse import SparseTextEmbedding
+from qdrant_client import AsyncQdrantClient
+from qdrant_client.models import (
+    FieldCondition,
+    Filter,
+    Fusion,
+    FusionQuery,
+    MatchAny,
+    MatchValue,
+    Prefetch,
+    Range,
+    SparseVector,
+)
+
+from app.domain.ports.vector_store import VectorStorePort
+
+logger = logging.getLogger(__name__)
+
+DENSE_VECTOR_NAME = "dense"
+SPARSE_VECTOR_NAME = "sparse"
+
+
+class QdrantSearchAdapter(VectorStorePort):
+    """Implements VectorStorePort using Qdrant hybrid search with RRF fusion."""
+
+    def __init__(
+        self,
+        url: str,
+        collection_name: str,
+        api_key: str | None = None,
+        prefetch_limit: int = 20,
+    ) -> None:
+        self._client = AsyncQdrantClient(url=url, api_key=api_key)
+        self._collection = collection_name
+        self._prefetch_limit = prefetch_limit
+        self._sparse_model = SparseTextEmbedding(model_name="Qdrant/bm25")
+
+    def _build_sparse_vector(self, text: str) -> SparseVector:
+        embeddings = list(self._sparse_model.embed([text]))
+        emb = embeddings[0]
+        return SparseVector(
+            indices=emb.indices.tolist(),
+            values=emb.values.tolist(),
+        )
+
+    def _build_filter(self, filters: dict[str, Any] | None) -> Filter | None:
+        if not filters:
+            return None
+
+        conditions: list[Any] = []
+
+        if level := filters.get("level"):
+            # include courses with null level too (missing data is OK)
+            conditions.append(
+                Filter(
+                    should=[
+                        FieldCondition(key="level", match=MatchValue(value=str(level))),
+                        FieldCondition(key="level", is_null=True),
+                    ]
+                )
+            )
+
+        if organization := filters.get("organization"):
+            conditions.append(
+                FieldCondition(key="organization", match=MatchValue(value=str(organization)))
+            )
+
+        if min_rating := filters.get("min_rating"):
+            conditions.append(FieldCondition(key="rating", range=Range(gte=float(min_rating))))
+
+        if skills := filters.get("skills"):
+            conditions.append(FieldCondition(key="skills", match=MatchAny(any=list(skills))))
+
+        if not conditions:
+            return None
+
+        return Filter(must=conditions)
+
+    async def hybrid_search(
+        self,
+        query_vector: list[float],
+        query_text: str,
+        limit: int = 10,
+        filters: dict[str, Any] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Hybrid search: Dense + Sparse with RRF fusion."""
+        sparse_vector = self._build_sparse_vector(query_text)
+        qdrant_filter = self._build_filter(filters)
+
+        results = await self._client.query_points(
+            collection_name=self._collection,
+            prefetch=[
+                Prefetch(
+                    query=query_vector,
+                    using=DENSE_VECTOR_NAME,
+                    limit=self._prefetch_limit,
+                    filter=qdrant_filter,
+                ),
+                Prefetch(
+                    query=sparse_vector,
+                    using=SPARSE_VECTOR_NAME,
+                    limit=self._prefetch_limit,
+                    filter=qdrant_filter,
+                ),
+            ],
+            query=FusionQuery(fusion=Fusion.RRF),
+            limit=limit,
+            with_payload=True,
+        )
+
+        hits = []
+        for point in results.points:
+            payload = dict(point.payload or {})
+            payload["_id"] = str(point.id)
+            payload["_score"] = point.score
+            hits.append(payload)
+
+        logger.debug("hybrid_search returned %d hits for query=%r", len(hits), query_text)
+        return hits
+
+    async def upsert(self, points: list[dict[str, Any]]) -> None:
+        """Not implemented for search adapter (use ingestion scripts)."""
+        raise NotImplementedError("Use seed_data.py for ingestion")
+
+    async def get_by_id(self, point_id: str) -> dict[str, Any] | None:
+        """Retrieve a single point by ID."""
+        results = await self._client.retrieve(
+            collection_name=self._collection,
+            ids=[point_id],
+            with_payload=True,
+        )
+        if not results:
+            return None
+        payload = dict(results[0].payload or {})
+        payload["_id"] = str(results[0].id)
+        return payload

--- a/ai/app/interfaces/api/routes.py
+++ b/ai/app/interfaces/api/routes.py
@@ -1,8 +1,64 @@
 """Litestar API route definitions."""
-from litestar import Litestar, get
-from litestar.config.cors import CORSConfig
 
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from litestar import Litestar, get, post
+from litestar.config.cors import CORSConfig
+from litestar.exceptions import HTTPException
+
+from app.config.container import build_container, get_container
 from app.config.settings import get_settings
+from app.domain.usecases.search_courses import SearchCoursesUseCase, SearchQuery, SearchResult
+from app.infrastructure.formatters import create_formatter
+from app.infrastructure.reranking import create_reranker
+
+# ---------------------------------------------------------------------------
+# Request / Response schemas
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class SearchRequest:
+    query: str
+    level: str | None = None
+    organization: str | None = None
+    min_rating: float | None = None
+    skills: list[str] | None = None
+    limit: int = 10
+    threshold: float | None = None
+    reranker: str | None = None
+    formatter: str | None = None
+
+
+@dataclass
+class CourseResponse:
+    id: str
+    title: str
+    organization: str
+    level: str | None
+    rating: float
+    enrolled: int
+    skills: list[str]
+    url: str
+    description: str
+    schedule: str | None
+    instructor: str | None
+
+
+@dataclass
+class SearchResponse:
+    courses: list[CourseResponse]
+    formatted_context: str
+    total_hits: int
+    reranker_applied: str
+    formatter_applied: str
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
 
 
 @get("/health")
@@ -16,11 +72,82 @@ async def health_check() -> dict[str, str]:
     }
 
 
+@post("/search")
+async def search_courses(data: SearchRequest) -> SearchResponse:
+    """
+    Hybrid RAG search endpoint.
+
+    Reranker and formatter can be overridden per-request; defaults come
+    from environment variables (RERANKER_STRATEGY / CONTEXT_FORMAT).
+    """
+    settings = get_settings()
+    container = get_container()
+
+    reranker_strategy = data.reranker or settings.RERANKER_STRATEGY
+    formatter_format = data.formatter or settings.CONTEXT_FORMAT
+
+    try:
+        reranker = create_reranker(reranker_strategy)
+        formatter = create_formatter(formatter_format)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    usecase = SearchCoursesUseCase(
+        vector_store=container.vector_store,
+        embedding=container.embedding,
+        reranker=reranker,
+        formatter=formatter,
+    )
+
+    query = SearchQuery(
+        query=data.query,
+        level=data.level,
+        organization=data.organization,
+        min_rating=data.min_rating,
+        skills=data.skills,
+        limit=data.limit,
+        threshold=data.threshold if data.threshold is not None else settings.SIMILARITY_THRESHOLD,
+    )
+
+    result: SearchResult = await usecase.execute(query)
+
+    return SearchResponse(
+        courses=[
+            CourseResponse(
+                id=c.id,
+                title=c.title,
+                organization=c.organization,
+                level=c.level,
+                rating=c.rating,
+                enrolled=c.enrolled,
+                skills=c.skills,
+                url=c.url,
+                description=c.description,
+                schedule=c.schedule,
+                instructor=c.instructor,
+            )
+            for c in result.courses
+        ],
+        formatted_context=result.formatted_context,
+        total_hits=result.total_hits,
+        reranker_applied=result.reranker_applied,
+        formatter_applied=result.formatter_applied,
+    )
+
+
+# ---------------------------------------------------------------------------
+# App factory
+# ---------------------------------------------------------------------------
+
+
 def create_app() -> Litestar:
     """Create and configure the Litestar application."""
     cors_config = CORSConfig(allow_origins=["*"])
 
+    # Wire up DI container at startup
+    build_container()
+
     return Litestar(
-        route_handlers=[health_check],
+        route_handlers=[health_check, search_courses],
         cors_config=cors_config,
     )

--- a/ai/tests/unit/infrastructure/test_formatters.py
+++ b/ai/tests/unit/infrastructure/test_formatters.py
@@ -1,0 +1,99 @@
+"""Unit tests for Formatter strategies."""
+
+import json
+
+import pytest
+
+from app.domain.entities.course import CourseFactory
+from app.infrastructure.formatters import JsonFormatter, ToonFormatter, create_formatter
+
+
+def _make_course(**kwargs):  # type: ignore[no-untyped-def]
+    defaults = dict(
+        title="Python for Everybody",
+        description="Learn Python programming",
+        skills=["Python", "Data Structures"],
+        level="Beginner",
+        organization="University of Michigan",
+        rating=4.8,
+        enrolled=1_000_000,
+        num_reviews=50000,
+        modules=None,
+        schedule="4 weeks",
+        url="https://coursera.org/python",
+        instructor="Chuck",
+        search_text="python beginner",
+    )
+    defaults.update(kwargs)
+    return CourseFactory.create(**defaults)
+
+
+class TestJsonFormatter:
+    def test_format_single_course(self) -> None:
+        course = _make_course()
+        result = JsonFormatter().format([course])
+        data = json.loads(result)
+        assert "courses" in data
+        assert len(data["courses"]) == 1
+        c = data["courses"][0]
+        assert c["title"] == "Python for Everybody"
+        assert c["organization"] == "University of Michigan"
+        assert c["level"] == "Beginner"
+        assert c["rating"] == 4.8
+        assert "Python" in c["skills"]
+
+    def test_format_empty(self) -> None:
+        result = JsonFormatter().format([])
+        data = json.loads(result)
+        assert data["courses"] == []
+
+    def test_format_multiple_courses(self) -> None:
+        courses = [_make_course(title=f"Course {i}") for i in range(3)]
+        result = JsonFormatter().format(courses)
+        data = json.loads(result)
+        assert len(data["courses"]) == 3
+
+
+class TestToonFormatter:
+    def test_format_single_course(self) -> None:
+        course = _make_course()
+        result = ToonFormatter().format([course])
+        assert result.startswith("courses[1]{")
+        assert "title,org,level,rating,enrolled,skills" in result
+        assert "Python for Everybody" in result
+        assert "University of Michigan" in result
+        assert "Beginner" in result
+
+    def test_format_empty(self) -> None:
+        result = ToonFormatter().format([])
+        assert "courses[0]" in result
+        assert "no results" in result
+
+    def test_skills_with_comma_are_quoted(self) -> None:
+        course = _make_course(skills=["Python", "Data Structures"])
+        result = ToonFormatter().format([course])
+        assert '"Python, Data Structures"' in result
+
+    def test_title_with_comma_is_quoted(self) -> None:
+        course = _make_course(title="R, Python, and Statistics")
+        result = ToonFormatter().format([course])
+        assert '"R, Python, and Statistics"' in result
+
+    def test_format_multiple_courses(self) -> None:
+        courses = [_make_course(title=f"Course {i}") for i in range(5)]
+        result = ToonFormatter().format(courses)
+        assert result.startswith("courses[5]{")
+        lines = result.strip().split("\n")
+        assert len(lines) == 6  # header + 5 data rows
+
+
+class TestCreateFormatter:
+    def test_json(self) -> None:
+        assert isinstance(create_formatter("json"), JsonFormatter)
+
+    def test_toon(self) -> None:
+        assert isinstance(create_formatter("toon"), ToonFormatter)
+
+    def test_unknown_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown formatter"):
+            create_formatter("xml")

--- a/ai/tests/unit/infrastructure/test_rerankers.py
+++ b/ai/tests/unit/infrastructure/test_rerankers.py
@@ -1,0 +1,84 @@
+"""Unit tests for Reranker strategies."""
+
+import pytest
+
+from app.infrastructure.reranking import (
+    HeuristicReranker,
+    NoReranker,
+    create_reranker,
+)
+from app.infrastructure.reranking.base import BaseReranker
+
+
+def _make_results(n: int = 5) -> list[dict]:  # type: ignore[type-arg]
+    return [
+        {
+            "_id": str(i),
+            "_score": 1.0 - i * 0.1,
+            "title": f"Course {i}",
+            "description": f"Description {i}",
+            "rating": 5.0 - i * 0.3,
+            "enrolled": (5 - i) * 10_000,
+        }
+        for i in range(n)
+    ]
+
+
+class TestNoReranker:
+    def test_returns_top_k(self) -> None:
+        results = _make_results(5)
+        reranked = NoReranker().rerank("query", results, top_k=3)
+        assert len(reranked) == 3
+
+    def test_preserves_order(self) -> None:
+        results = _make_results(5)
+        reranked = NoReranker().rerank("query", results, top_k=5)
+        assert [r["_id"] for r in reranked] == [str(i) for i in range(5)]
+
+    def test_empty_input(self) -> None:
+        assert NoReranker().rerank("query", [], top_k=10) == []
+
+    def test_top_k_larger_than_results(self) -> None:
+        results = _make_results(3)
+        reranked = NoReranker().rerank("query", results, top_k=10)
+        assert len(reranked) == 3
+
+
+class TestHeuristicReranker:
+    def test_returns_top_k(self) -> None:
+        results = _make_results(5)
+        reranked = HeuristicReranker().rerank("query", results, top_k=3)
+        assert len(reranked) == 3
+
+    def test_higher_rating_promoted_when_relevance_equal(self) -> None:
+        # Both items have identical relevance; rating and enrolled decide the winner
+        results = [
+            {"_id": "low", "_score": 0.8, "title": "Low", "rating": 1.0, "enrolled": 100},
+            {"_id": "high", "_score": 0.8, "title": "High", "rating": 5.0, "enrolled": 1_000_000},
+        ]
+        reranked = HeuristicReranker().rerank("query", results, top_k=2)
+        assert reranked[0]["_id"] == "high"
+
+    def test_empty_input(self) -> None:
+        assert HeuristicReranker().rerank("query", [], top_k=10) == []
+
+    def test_single_result(self) -> None:
+        results = _make_results(1)
+        reranked = HeuristicReranker().rerank("query", results, top_k=1)
+        assert len(reranked) == 1
+
+
+class TestCreateReranker:
+    def test_none(self) -> None:
+        assert isinstance(create_reranker("none"), NoReranker)
+
+    def test_heuristic(self) -> None:
+        assert isinstance(create_reranker("heuristic"), HeuristicReranker)
+
+    def test_unknown_raises(self) -> None:
+        with pytest.raises(ValueError, match="Unknown reranker"):
+            create_reranker("unknown-strategy")
+
+    def test_all_are_base_reranker(self) -> None:
+        for strategy in ("none", "heuristic"):
+            assert isinstance(create_reranker(strategy), BaseReranker)


### PR DESCRIPTION
## Summary

- **QdrantSearchAdapter**: Dense + Sparse の Hybrid Search、RRF fusion でスコア統合 (ADR-012-3)
- **Reranker Strategy**: `NoReranker` / `HeuristicReranker` / `CrossEncoderReranker` を環境変数 `RERANKER_STRATEGY` で切替 (ADR-012-5)
- **Formatter Strategy**: `JsonFormatter` / `ToonFormatter` を環境変数 `CONTEXT_FORMAT` で切替。TOON形式でトークン約50%削減 (ADR-012-6)
- **SearchCoursesUseCase**: 閾値フィルタ + Corrective RAG (最大2回リトライ、Denial-of-Wallet対策)
- **POST /search**: reranker / formatter をリクエスト単位でオーバーライド可能

## Test plan

- [x] `uv run pytest tests/unit/ -q` → 63 tests pass
- [x] `uv run ruff check .` → All checks passed
- [x] `uv run mypy app/` → Success: no issues found

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)