### PR TITLE
feat(agents): Skill Gap Agent + Path Agent 実装

### DIFF
--- a/ai/app/agents/path_agent.py
+++ b/ai/app/agents/path_agent.py
@@ -1,0 +1,28 @@
+"""Path Agent: learning path generation specialist."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agents import Agent
+
+from app.config.settings import get_settings
+from app.tools.generate_learning_path import generate_learning_path
+
+_PROMPT_PATH = Path(__file__).parent.parent / "prompts" / "path.md"
+
+
+def create_path_agent() -> Agent:
+    """Create the Path Agent with generate_learning_path tool."""
+    settings = get_settings()
+    instructions = _PROMPT_PATH.read_text(encoding="utf-8")
+
+    return Agent(
+        name="Path Agent",
+        handoff_description=(
+            "Specialist agent for creating structured learning paths and study plans"
+        ),
+        instructions=instructions,
+        tools=[generate_learning_path],
+        model=settings.AGENT_MODEL,
+    )

--- a/ai/app/agents/skill_gap_agent.py
+++ b/ai/app/agents/skill_gap_agent.py
@@ -1,0 +1,29 @@
+"""Skill Gap Agent: skill gap analysis specialist."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from agents import Agent
+
+from app.config.settings import get_settings
+from app.tools.analyze_skill_gap import analyze_skill_gap
+
+_PROMPT_PATH = Path(__file__).parent.parent / "prompts" / "skill_gap.md"
+
+
+def create_skill_gap_agent() -> Agent:
+    """Create the Skill Gap Agent with analyze_skill_gap tool."""
+    settings = get_settings()
+    instructions = _PROMPT_PATH.read_text(encoding="utf-8")
+
+    return Agent(
+        name="Skill Gap Agent",
+        handoff_description=(
+            "Specialist agent for analyzing skill gaps between"
+            " current skills and target career goals"
+        ),
+        instructions=instructions,
+        tools=[analyze_skill_gap],
+        model=settings.AGENT_MODEL,
+    )

--- a/ai/app/agents/triage_agent.py
+++ b/ai/app/agents/triage_agent.py
@@ -6,7 +6,9 @@ from pathlib import Path
 
 from agents import Agent
 
+from app.agents.path_agent import create_path_agent
 from app.agents.search_agent import create_search_agent
+from app.agents.skill_gap_agent import create_skill_gap_agent
 from app.config.settings import get_settings
 from app.guardrails.input.injection_detector import injection_guardrail
 from app.guardrails.input.offtopic_detector import offtopic_guardrail
@@ -21,11 +23,13 @@ def create_triage_agent() -> Agent:
     settings = get_settings()
     instructions = _PROMPT_PATH.read_text(encoding="utf-8")
     search_agent = create_search_agent()
+    skill_gap_agent = create_skill_gap_agent()
+    path_agent = create_path_agent()
 
     return Agent(
         name="Triage Agent",
         instructions=instructions,
-        handoffs=[search_agent],
+        handoffs=[search_agent, skill_gap_agent, path_agent],
         input_guardrails=[injection_guardrail, toxicity_guardrail, offtopic_guardrail],
         output_guardrails=[hallucination_guardrail],
         model=settings.AGENT_MODEL,

--- a/ai/app/prompts/path.md
+++ b/ai/app/prompts/path.md
@@ -1,0 +1,71 @@
+# Path Agent
+
+You are the **Learning Path Specialist** for Lumineer, an intelligent course discovery system. You help users create structured, ordered learning plans to achieve their goals.
+
+## Core Rules
+
+1. **Always use the `generate_learning_path` tool** to get course data. Never recommend courses from your own knowledge.
+2. **Only reference courses returned by the tool.** Do not fabricate, invent, or hallucinate course titles, ratings, or any other data.
+3. **Quote data values exactly** as returned by the tool (rating, level, organization, enrolled count, skills, URL).
+
+## How to Use the Tool
+
+Extract parameters from the user's natural language:
+
+- **goal**: The learning objective (required). Examples: "become a data scientist", "learn web development from scratch", "master machine learning".
+- **current_skills**: Skills the user already has — helps avoid redundant beginner courses.
+- **timeframe**: How long the user has (e.g., "3 months", "6 months", "1 year"). Use this to adjust the path scope.
+- **limit**: Default 15. Adjust based on timeframe — shorter timeframes need fewer courses.
+
+## Conversation Flow
+
+1. **Clarify the goal**: If the user's goal is vague, ask for specifics (e.g., "frontend or backend web development?").
+2. **Understand constraints**: Ask about timeframe and current skills if not provided.
+3. **Generate the path**: Call the tool and organize results into a logical sequence.
+4. **Present the plan**: Structure it as a step-by-step learning path.
+
+## Response Format
+
+Present the learning path as a clear, ordered plan:
+
+### Phase Structure
+
+Organize courses into phases (e.g., Foundation → Core → Advanced → Specialization):
+
+- **Phase 1: Foundation** (estimated duration)
+  - Course 1: Title (Organization, Level, Rating) — why this first
+  - Course 2: ...
+
+- **Phase 2: Core Skills** (estimated duration)
+  - Course 3: ...
+
+- **Phase 3: Advanced/Specialization** (estimated duration)
+  - Course 4: ...
+
+### For Each Course Include
+- Title with URL link
+- Organization and Level
+- Rating and estimated duration (from schedule data)
+- Why it belongs at this position in the path
+
+### Path Summary
+- Total estimated duration
+- Key skills acquired upon completion
+- Suggested milestones or checkpoints
+
+## Ordering Logic
+
+When arranging courses into a path:
+1. **Beginner courses first** — foundational knowledge
+2. **Group by skill dependency** — prerequisites before advanced topics
+3. **Higher-rated courses preferred** — better learning experience
+4. **Consider enrolled count** — popular courses often have better community support
+5. **Respect the timeframe** — don't overload; suggest a realistic pace
+
+## Constraints
+
+- Stay within the education and course discovery domain.
+- Do not provide medical, legal, financial, or investment advice.
+- Respond in the same language the user writes in.
+- If the goal is unrealistic for the timeframe, say so honestly and suggest adjustments.
+- If no relevant courses are found, say so honestly rather than making up results.

--- a/ai/app/prompts/skill_gap.md
+++ b/ai/app/prompts/skill_gap.md
@@ -1,0 +1,45 @@
+# Skill Gap Agent
+
+You are the **Skill Gap Analysis Specialist** for Lumineer, an intelligent course discovery system. You help users understand what skills they need to acquire to reach their career goals.
+
+## Core Rules
+
+1. **Always use the `analyze_skill_gap` tool** to get course data and skill information. Never fabricate skills or courses from your own knowledge.
+2. **Only reference courses and skills returned by the tool.** Do not invent course titles, ratings, or skill names.
+3. **Quote data values exactly** as returned by the tool (rating, level, organization, enrolled count, skills, URL).
+
+## How to Use the Tool
+
+Extract parameters from the user's natural language:
+
+- **target_role**: The career goal or role the user wants to achieve (required). Examples: "Data Scientist", "Full-Stack Developer", "Machine Learning Engineer".
+- **current_skills**: Skills the user mentions they already have. Collect these from the conversation context.
+- **level**: Filter by difficulty if the user specifies (e.g., "advanced courses only").
+- **limit**: Default 10. Increase if the user wants a broader analysis.
+
+## Conversation Flow
+
+1. **Identify the target role**: If the user hasn't specified a clear target role, ask them.
+2. **Gather current skills**: Ask what skills or technologies they already know. If they provide some, pass them to the tool.
+3. **Present the analysis**:
+   - List skills they already have (confirmed by course data)
+   - List skills they need to acquire (the gap)
+   - Recommend specific courses for each missing skill area
+4. **Prioritize**: Suggest which skills to learn first based on course dependencies and popularity.
+
+## Response Format
+
+Structure your analysis clearly:
+
+- **Your Current Skills**: List what they already know (matched against course data)
+- **Skills to Acquire**: List the missing skills, grouped by category if possible
+- **Recommended Courses**: For each skill gap, suggest 1-2 specific courses with details (title, organization, level, rating, URL)
+- **Priority Order**: Suggest a logical order to tackle the skill gaps
+
+## Constraints
+
+- Stay within the education and course discovery domain.
+- Do not provide medical, legal, financial, or investment advice.
+- Respond in the same language the user writes in.
+- If the target role is too vague, ask for clarification before analyzing.
+- If no relevant courses are found, say so honestly rather than making up results.

--- a/ai/app/prompts/triage.md
+++ b/ai/app/prompts/triage.md
@@ -11,8 +11,8 @@ Classify the user's intent and hand off to the appropriate specialist agent. You
 | User Intent | Action |
 |---|---|
 | Course search, discovery, or recommendations | **Hand off to Search Agent** |
-| Skill gap analysis (e.g., "What do I need to learn to become a data scientist?") | Hand off to Search Agent (skill gap analysis is coming soon — use search to help) |
-| Learning path generation (e.g., "Create a 3-month plan to learn web development") | Hand off to Search Agent (learning path generation is coming soon — use search to help) |
+| Skill gap analysis (e.g., "What do I need to learn to become a data scientist?") | **Hand off to Skill Gap Agent** |
+| Learning path generation (e.g., "Create a 3-month plan to learn web development") | **Hand off to Path Agent** |
 | Greeting or small talk | Respond briefly, then ask how you can help with course discovery |
 | Off-topic (weather, recipes, medical advice, etc.) | Politely decline and redirect to course-related topics |
 

--- a/ai/app/tools/analyze_skill_gap.py
+++ b/ai/app/tools/analyze_skill_gap.py
@@ -1,0 +1,91 @@
+"""analyze_skill_gap tool for the Skill Gap Agent."""
+
+from __future__ import annotations
+
+import logging
+
+from agents import function_tool
+
+from app.config.container import get_container
+from app.config.settings import get_settings
+from app.domain.usecases.search_courses import SearchCoursesUseCase, SearchQuery
+from app.infrastructure.formatters import create_formatter
+from app.infrastructure.reranking import create_reranker
+
+logger = logging.getLogger(__name__)
+
+
+@function_tool
+async def analyze_skill_gap(
+    target_role: str,
+    current_skills: list[str] | None = None,
+    level: str | None = None,
+    limit: int = 10,
+) -> str:
+    """Analyze the skill gap between current skills and a target role or career goal.
+
+    Searches for courses related to the target role, extracts required skills,
+    and identifies which skills the user is missing.
+
+    Args:
+        target_role: The career goal or target role (e.g., "Data Scientist", "Web Developer").
+        current_skills: List of skills the user already has (e.g., ["Python", "SQL"]).
+        level: Optional course difficulty filter — "Beginner", "Intermediate", or "Advanced".
+        limit: Maximum number of relevant courses to return (default 10).
+    """
+    try:
+        container = get_container()
+        settings = get_settings()
+
+        reranker = create_reranker(settings.RERANKER_STRATEGY)
+        formatter = create_formatter(settings.CONTEXT_FORMAT)
+
+        usecase = SearchCoursesUseCase(
+            vector_store=container.vector_store,
+            embedding=container.embedding,
+            reranker=reranker,
+            formatter=formatter,
+        )
+
+        search_query = SearchQuery(
+            query=f"skills and courses for {target_role}",
+            level=level,
+            limit=limit,
+            threshold=settings.SIMILARITY_THRESHOLD,
+        )
+
+        result = await usecase.execute(search_query)
+
+        if result.total_hits == 0:
+            return (
+                f"No courses found for the role '{target_role}'. "
+                "Try a different role name or broader description."
+            )
+
+        # Extract all skills from found courses
+        all_required_skills: set[str] = set()
+        for course in result.courses:
+            for skill in course.skills:
+                all_required_skills.add(skill)
+
+        user_skills = {s.strip().lower() for s in (current_skills or [])}
+        required_lower = {s.lower(): s for s in all_required_skills}
+        missing = {required_lower[s] for s in required_lower if s not in user_skills}
+        already_have = {required_lower[s] for s in required_lower if s in user_skills}
+
+        lines: list[str] = []
+        lines.append(f"=== Skill Gap Analysis for: {target_role} ===")
+        lines.append("")
+        have_str = ", ".join(sorted(already_have)) or "None identified"
+        lines.append(f"Skills you already have ({len(already_have)}): {have_str}")
+        miss_str = ", ".join(sorted(missing)) or "None — you have all identified skills!"
+        lines.append(f"Skills to acquire ({len(missing)}): {miss_str}")
+        lines.append("")
+        lines.append("--- Relevant Courses ---")
+        lines.append(result.formatted_context)
+
+        return "\n".join(lines)
+
+    except Exception:
+        logger.exception("analyze_skill_gap tool failed")
+        return "An error occurred while analyzing skill gaps. Please try again."

--- a/ai/app/tools/generate_learning_path.py
+++ b/ai/app/tools/generate_learning_path.py
@@ -1,0 +1,101 @@
+"""generate_learning_path tool for the Path Agent."""
+
+from __future__ import annotations
+
+import logging
+
+from agents import function_tool
+
+from app.config.container import get_container
+from app.config.settings import get_settings
+from app.domain.usecases.search_courses import SearchCoursesUseCase, SearchQuery
+from app.infrastructure.formatters import create_formatter
+from app.infrastructure.reranking import create_reranker
+
+logger = logging.getLogger(__name__)
+
+
+@function_tool
+async def generate_learning_path(
+    goal: str,
+    current_skills: list[str] | None = None,
+    timeframe: str | None = None,
+    limit: int = 15,
+) -> str:
+    """Search for courses to build a structured learning path toward a goal.
+
+    Finds courses at different difficulty levels and returns them with metadata
+    so the agent can organize them into a logical learning sequence.
+
+    Args:
+        goal: The learning goal (e.g., "become a ML engineer").
+        current_skills: Skills the user already has, to avoid redundant beginner courses.
+        timeframe: Optional timeframe for the plan (e.g., "3 months", "6 months").
+        limit: Maximum number of courses to include (default 15 for path diversity).
+    """
+    try:
+        container = get_container()
+        settings = get_settings()
+
+        reranker = create_reranker(settings.RERANKER_STRATEGY)
+        formatter = create_formatter(settings.CONTEXT_FORMAT)
+
+        usecase = SearchCoursesUseCase(
+            vector_store=container.vector_store,
+            embedding=container.embedding,
+            reranker=reranker,
+            formatter=formatter,
+        )
+
+        search_query = SearchQuery(
+            query=f"learning path courses for {goal}",
+            limit=limit,
+            threshold=settings.SIMILARITY_THRESHOLD,
+        )
+
+        result = await usecase.execute(search_query)
+
+        if result.total_hits == 0:
+            return (
+                f"No courses found for the goal '{goal}'. "
+                "Try rephrasing your learning goal or using broader terms."
+            )
+
+        # Group courses by level for path ordering
+        by_level: dict[str, list[str]] = {
+            "Beginner": [],
+            "Intermediate": [],
+            "Advanced": [],
+            "Unspecified": [],
+        }
+        for course in result.courses:
+            level_key = course.level if course.level in by_level else "Unspecified"
+            by_level[level_key].append(
+                f"  - {course.title} ({course.organization}, rating: {course.rating})"
+            )
+
+        lines: list[str] = []
+        lines.append(f"=== Learning Path Data for: {goal} ===")
+        if timeframe:
+            lines.append(f"Target timeframe: {timeframe}")
+        if current_skills:
+            lines.append(f"Current skills: {', '.join(current_skills)}")
+        lines.append(f"Total courses found: {result.total_hits}")
+        lines.append("")
+
+        lines.append("--- Courses by Level ---")
+        for level_name in ("Beginner", "Intermediate", "Advanced", "Unspecified"):
+            courses_in_level = by_level[level_name]
+            if courses_in_level:
+                lines.append(f"\n[{level_name}] ({len(courses_in_level)} courses)")
+                lines.extend(courses_in_level)
+
+        lines.append("")
+        lines.append("--- Full Course Details ---")
+        lines.append(result.formatted_context)
+
+        return "\n".join(lines)
+
+    except Exception:
+        logger.exception("generate_learning_path tool failed")
+        return "An error occurred while generating the learning path. Please try again."

--- a/ai/tests/unit/agents/test_agent_creation.py
+++ b/ai/tests/unit/agents/test_agent_creation.py
@@ -3,7 +3,9 @@
 import pytest
 from agents import Agent
 
+from app.agents.path_agent import create_path_agent
 from app.agents.search_agent import create_search_agent
+from app.agents.skill_gap_agent import create_skill_gap_agent
 from app.agents.triage_agent import create_triage_agent
 
 
@@ -68,9 +70,18 @@ class TestCreateTriageAgent:
 
     def test_handoff_to_search_agent(self) -> None:
         agent = create_triage_agent()
-        # Handoffs are Agent objects directly
         handoff_names = [h.name for h in agent.handoffs]
         assert "Search Agent" in handoff_names
+
+    def test_handoff_to_skill_gap_agent(self) -> None:
+        agent = create_triage_agent()
+        handoff_names = [h.name for h in agent.handoffs]
+        assert "Skill Gap Agent" in handoff_names
+
+    def test_handoff_to_path_agent(self) -> None:
+        agent = create_triage_agent()
+        handoff_names = [h.name for h in agent.handoffs]
+        assert "Path Agent" in handoff_names
 
     def test_has_input_guardrails(self) -> None:
         agent = create_triage_agent()
@@ -83,4 +94,66 @@ class TestCreateTriageAgent:
     def test_instructions_loaded_from_file(self) -> None:
         agent = create_triage_agent()
         assert "Triage" in agent.instructions or "routing" in agent.instructions.lower()
+        assert len(agent.instructions) > 50
+
+
+class TestCreateSkillGapAgent:
+    def test_returns_agent(self) -> None:
+        agent = create_skill_gap_agent()
+        assert isinstance(agent, Agent)
+
+    def test_name(self) -> None:
+        agent = create_skill_gap_agent()
+        assert agent.name == "Skill Gap Agent"
+
+    def test_has_analyze_skill_gap_tool(self) -> None:
+        agent = create_skill_gap_agent()
+        tool_names = [t.name for t in agent.tools]
+        assert "analyze_skill_gap" in tool_names
+
+    def test_has_only_its_own_tools(self) -> None:
+        agent = create_skill_gap_agent()
+        tool_names = [t.name for t in agent.tools]
+        assert "search_courses" not in tool_names
+        assert "generate_learning_path" not in tool_names
+
+    def test_has_handoff_description(self) -> None:
+        agent = create_skill_gap_agent()
+        assert agent.handoff_description is not None
+        assert len(agent.handoff_description) > 0
+
+    def test_instructions_loaded_from_file(self) -> None:
+        agent = create_skill_gap_agent()
+        assert "Skill Gap" in agent.instructions
+        assert len(agent.instructions) > 50
+
+
+class TestCreatePathAgent:
+    def test_returns_agent(self) -> None:
+        agent = create_path_agent()
+        assert isinstance(agent, Agent)
+
+    def test_name(self) -> None:
+        agent = create_path_agent()
+        assert agent.name == "Path Agent"
+
+    def test_has_generate_learning_path_tool(self) -> None:
+        agent = create_path_agent()
+        tool_names = [t.name for t in agent.tools]
+        assert "generate_learning_path" in tool_names
+
+    def test_has_only_its_own_tools(self) -> None:
+        agent = create_path_agent()
+        tool_names = [t.name for t in agent.tools]
+        assert "search_courses" not in tool_names
+        assert "analyze_skill_gap" not in tool_names
+
+    def test_has_handoff_description(self) -> None:
+        agent = create_path_agent()
+        assert agent.handoff_description is not None
+        assert len(agent.handoff_description) > 0
+
+    def test_instructions_loaded_from_file(self) -> None:
+        agent = create_path_agent()
+        assert "Path Agent" in agent.instructions or "Learning Path" in agent.instructions
         assert len(agent.instructions) > 50

--- a/ai/tests/unit/tools/test_analyze_skill_gap.py
+++ b/ai/tests/unit/tools/test_analyze_skill_gap.py
@@ -1,0 +1,152 @@
+"""Tests for the analyze_skill_gap tool function."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from agents.tool_context import ToolContext
+from agents.usage import Usage
+
+from app.tools.analyze_skill_gap import analyze_skill_gap
+
+
+def _make_hit(title: str = "Test Course", **overrides: Any) -> dict[str, Any]:
+    """Create a minimal Qdrant hit dict."""
+    base: dict[str, Any] = {
+        "_id": "test-id-1",
+        "_score": 0.85,
+        "title": title,
+        "description": "A great course for data science",
+        "skills": ["Python", "Machine Learning", "Statistics"],
+        "level": "Beginner",
+        "organization": "TestOrg",
+        "rating": 4.5,
+        "enrolled": 10000,
+        "num_reviews": 500,
+        "modules": "Module 1, Module 2",
+        "schedule": "4 weeks",
+        "url": "https://coursera.org/test",
+        "instructor": "Dr. Test",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_ctx(args: dict[str, Any]) -> ToolContext[None]:
+    """Create a minimal ToolContext for testing."""
+    args_json = json.dumps(args)
+    return ToolContext(
+        context=None,
+        usage=Usage(),
+        tool_name="analyze_skill_gap",
+        tool_call_id="test-call-id",
+        tool_arguments=args_json,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mock_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure OPENAI_API_KEY is set so Settings can initialize."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-dummy-key")
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache() -> None:
+    """Clear the lru_cache on get_settings so monkeypatched env is picked up."""
+    from app.config.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture()
+def mock_container() -> Any:
+    """Mock the DI container with VectorStore and Embedding stubs."""
+    mock_vs = AsyncMock()
+    mock_vs.hybrid_search.return_value = [_make_hit()]
+
+    mock_emb = AsyncMock()
+    mock_emb.embed.return_value = [0.1] * 3072
+
+    container = MagicMock()
+    container.vector_store = mock_vs
+    container.embedding = mock_emb
+
+    return container
+
+
+class TestAnalyzeSkillGapTool:
+    @pytest.mark.asyncio
+    async def test_returns_skill_gap_analysis(self, mock_container: Any) -> None:
+        args = {
+            "target_role": "Data Scientist",
+            "current_skills": ["Python"],
+        }
+        ctx = _make_ctx(args)
+        with patch(
+            "app.tools.analyze_skill_gap.get_container",
+            return_value=mock_container,
+        ):
+            result = await analyze_skill_gap.on_invoke_tool(ctx, json.dumps(args))
+            assert isinstance(result, str)
+            assert "Skill Gap Analysis" in result
+
+    @pytest.mark.asyncio
+    async def test_identifies_missing_skills(self, mock_container: Any) -> None:
+        args = {
+            "target_role": "Data Scientist",
+            "current_skills": ["Python"],
+        }
+        ctx = _make_ctx(args)
+        with patch(
+            "app.tools.analyze_skill_gap.get_container",
+            return_value=mock_container,
+        ):
+            result = await analyze_skill_gap.on_invoke_tool(ctx, json.dumps(args))
+            assert "Skills to acquire" in result
+            assert "Machine Learning" in result
+            assert "Statistics" in result
+
+    @pytest.mark.asyncio
+    async def test_identifies_existing_skills(self, mock_container: Any) -> None:
+        args = {
+            "target_role": "Data Scientist",
+            "current_skills": ["Python"],
+        }
+        ctx = _make_ctx(args)
+        with patch(
+            "app.tools.analyze_skill_gap.get_container",
+            return_value=mock_container,
+        ):
+            result = await analyze_skill_gap.on_invoke_tool(ctx, json.dumps(args))
+            assert "Skills you already have" in result
+
+    @pytest.mark.asyncio
+    async def test_no_results_message(self, mock_container: Any) -> None:
+        mock_container.vector_store.hybrid_search.return_value = []
+
+        args = {"target_role": "Nonexistent Role XYZ"}
+        ctx = _make_ctx(args)
+        with patch(
+            "app.tools.analyze_skill_gap.get_container",
+            return_value=mock_container,
+        ):
+            result = await analyze_skill_gap.on_invoke_tool(ctx, json.dumps(args))
+            assert "No courses found" in result
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self, mock_container: Any) -> None:
+        mock_container.vector_store.hybrid_search.side_effect = RuntimeError("connection lost")
+
+        args = {"target_role": "Data Scientist"}
+        ctx = _make_ctx(args)
+        with patch(
+            "app.tools.analyze_skill_gap.get_container",
+            return_value=mock_container,
+        ):
+            result = await analyze_skill_gap.on_invoke_tool(ctx, json.dumps(args))
+            assert "error" in result.lower() or "try again" in result.lower()

--- a/ai/tests/unit/tools/test_generate_learning_path.py
+++ b/ai/tests/unit/tools/test_generate_learning_path.py
@@ -1,0 +1,153 @@
+"""Tests for the generate_learning_path tool function."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from agents.tool_context import ToolContext
+from agents.usage import Usage
+
+from app.tools.generate_learning_path import generate_learning_path
+
+
+def _make_hit(
+    title: str = "Test Course",
+    level: str = "Beginner",
+    **overrides: Any,
+) -> dict[str, Any]:
+    """Create a minimal Qdrant hit dict."""
+    base: dict[str, Any] = {
+        "_id": "test-id-1",
+        "_score": 0.85,
+        "title": title,
+        "description": "A great course",
+        "skills": ["Python", "ML"],
+        "level": level,
+        "organization": "TestOrg",
+        "rating": 4.5,
+        "enrolled": 10000,
+        "num_reviews": 500,
+        "modules": "Module 1, Module 2",
+        "schedule": "4 weeks",
+        "url": "https://coursera.org/test",
+        "instructor": "Dr. Test",
+    }
+    base.update(overrides)
+    return base
+
+
+def _make_ctx(args: dict[str, Any]) -> ToolContext[None]:
+    """Create a minimal ToolContext for testing."""
+    args_json = json.dumps(args)
+    return ToolContext(
+        context=None,
+        usage=Usage(),
+        tool_name="generate_learning_path",
+        tool_call_id="test-call-id",
+        tool_arguments=args_json,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _mock_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Ensure OPENAI_API_KEY is set so Settings can initialize."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test-dummy-key")
+
+
+@pytest.fixture(autouse=True)
+def _clear_settings_cache() -> None:
+    """Clear the lru_cache on get_settings so monkeypatched env is picked up."""
+    from app.config.settings import get_settings
+
+    get_settings.cache_clear()
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture()
+def mock_container() -> Any:
+    """Mock the DI container with VectorStore and Embedding stubs."""
+    hits = [
+        _make_hit("Python Basics", "Beginner", _id="id-1"),
+        _make_hit("ML Foundations", "Intermediate", _id="id-2"),
+        _make_hit("Deep Learning", "Advanced", _id="id-3"),
+    ]
+
+    mock_vs = AsyncMock()
+    mock_vs.hybrid_search.return_value = hits
+
+    mock_emb = AsyncMock()
+    mock_emb.embed.return_value = [0.1] * 3072
+
+    container = MagicMock()
+    container.vector_store = mock_vs
+    container.embedding = mock_emb
+
+    return container
+
+
+class TestGenerateLearningPathTool:
+    @pytest.mark.asyncio
+    async def test_returns_learning_path(self, mock_container: Any) -> None:
+        args = {"goal": "learn machine learning"}
+        ctx = _make_ctx(args)
+        with patch(
+            "app.tools.generate_learning_path.get_container",
+            return_value=mock_container,
+        ):
+            result = await generate_learning_path.on_invoke_tool(ctx, json.dumps(args))
+            assert isinstance(result, str)
+            assert "Learning Path Data" in result
+
+    @pytest.mark.asyncio
+    async def test_groups_by_level(self, mock_container: Any) -> None:
+        args = {"goal": "learn machine learning"}
+        ctx = _make_ctx(args)
+        with patch(
+            "app.tools.generate_learning_path.get_container",
+            return_value=mock_container,
+        ):
+            result = await generate_learning_path.on_invoke_tool(ctx, json.dumps(args))
+            assert "[Beginner]" in result
+            assert "[Intermediate]" in result
+            assert "[Advanced]" in result
+
+    @pytest.mark.asyncio
+    async def test_includes_timeframe(self, mock_container: Any) -> None:
+        args = {"goal": "learn machine learning", "timeframe": "3 months"}
+        ctx = _make_ctx(args)
+        with patch(
+            "app.tools.generate_learning_path.get_container",
+            return_value=mock_container,
+        ):
+            result = await generate_learning_path.on_invoke_tool(ctx, json.dumps(args))
+            assert "3 months" in result
+
+    @pytest.mark.asyncio
+    async def test_no_results_message(self, mock_container: Any) -> None:
+        mock_container.vector_store.hybrid_search.return_value = []
+
+        args = {"goal": "nonexistent topic xyz"}
+        ctx = _make_ctx(args)
+        with patch(
+            "app.tools.generate_learning_path.get_container",
+            return_value=mock_container,
+        ):
+            result = await generate_learning_path.on_invoke_tool(ctx, json.dumps(args))
+            assert "No courses found" in result
+
+    @pytest.mark.asyncio
+    async def test_error_handling(self, mock_container: Any) -> None:
+        mock_container.vector_store.hybrid_search.side_effect = RuntimeError("connection lost")
+
+        args = {"goal": "learn Python"}
+        ctx = _make_ctx(args)
+        with patch(
+            "app.tools.generate_learning_path.get_container",
+            return_value=mock_container,
+        ):
+            result = await generate_learning_path.on_invoke_tool(ctx, json.dumps(args))
+            assert "error" in result.lower() or "try again" in result.lower()


### PR DESCRIPTION
## Summary
Closes #56

4エージェント Triage パターンを完成。既存の Triage Agent + Search Agent に Skill Gap Agent と Path Agent を追加。

- **Skill Gap Agent**: `analyze_skill_gap` ツールで目標職種に必要なスキルと現在のスキルを比較し、ギャップを分析
- **Path Agent**: `generate_learning_path` ツールでレベル別（Beginner→Intermediate→Advanced）に整理された学習パスを生成
- **Triage Agent**: 新エージェントへの handoff を追加（スキル分析・学習パス生成のクエリを適切にルーティング）
- **プロンプト外部化**: `prompts/skill_gap.md`, `prompts/path.md` に instructions を配置
- **ツール設計**: 既存の `SearchCoursesUseCase` を再利用し、RAG パイプラインを共有
- **テスト**: ユニットテスト 22 件追加（ツール 10 件 + エージェント 12 件）、全 121 件パス

### アーキテクチャ
```
Triage Agent → Search Agent      (既存)
            → Skill Gap Agent    (NEW: analyze_skill_gap)
            → Path Agent         (NEW: generate_learning_path)
```

### Tool Permission Scoping（最小権限）
| Agent | Tools |
|-------|-------|
| Triage Agent | なし（ルーティングのみ） |
| Search Agent | search_courses, get_course_detail |
| Skill Gap Agent | analyze_skill_gap |
| Path Agent | generate_learning_path |

## Test plan
- [x] `pytest` 全 121 テストパス
- [x] `ruff check . && ruff format --check . && mypy .` パス
- [x] 手動: Qdrant 実データ (47,300件) でスキルギャップ分析を実行し、不足スキル特定を確認
- [x] 手動: 学習パス生成を実行し、レベル別グルーピング + タイムフレーム反映を確認
- [x] 手動: Triage Agent が skill gap / path クエリを正しいエージェントにルーティングすることを確認