### PR TITLE
fix(gateway): remove Host header before proxying to backend

### DIFF
--- a/gateway/src/routes/proxy.ts
+++ b/gateway/src/routes/proxy.ts
@@ -13,6 +13,8 @@ proxy.all("/api/*", async (c) => {
   const target = `${BACKEND_URL}${url.pathname}${url.search}`
 
   const reqHeaders = new Headers(c.req.raw.headers)
+  // Remove Host header so fetch sets the correct host from the target URL (Cloud Run routing)
+  reqHeaders.delete("host")
   // Forward real client IP for downstream logging
   reqHeaders.set("x-forwarded-for", c.req.header("x-forwarded-for") ?? "unknown")
 


### PR DESCRIPTION
## Summary

- Gateway was forwarding all request headers including \`Host: lumineer-gateway-*.run.app\` to the backend service
- Cloud Run routes requests based on the \`Host\` header, causing it to misroute/timeout when it received the gateway's own hostname
- Fix: delete \`Host\` header before \`fetch()\` so Cloud Run uses the correct host from \`BACKEND_URL\`

## Test plan

- [ ] CI passes (lint + typecheck)
- [ ] After merge → deploy to main, verify \`POST /api/auth/register\` returns 201 (not timeout)
- [ ] Verify Gateway → Backend proxying works end-to-end

Closes #94