### PR TITLE
fix(ai): Qdrant level filter の is_null に IsNullCondition を使用

### DIFF
--- a/ai/app/infrastructure/vectordb/qdrant_search_adapter.py
+++ b/ai/app/infrastructure/vectordb/qdrant_search_adapter.py
@@ -12,8 +12,10 @@ from qdrant_client.models import (
     Filter,
     Fusion,
     FusionQuery,
+    IsNullCondition,
     MatchAny,
     MatchValue,
+    PayloadField,
     Prefetch,
     Range,
     SparseVector,
@@ -62,7 +64,7 @@ class QdrantSearchAdapter(VectorStorePort):
                 Filter(
                     should=[
                         FieldCondition(key="level", match=MatchValue(value=str(level))),
-                        FieldCondition(key="level", is_null=True),
+                        IsNullCondition(is_null=PayloadField(key="level")),
                     ]
                 )
             )


### PR DESCRIPTION
## Summary

- `FieldCondition(key="level", is_null=True)` が空オブジェクト `{}` にシリアライズされ Qdrant が 422 を返す問題を修正
- `IsNullCondition(is_null=PayloadField(key="level"))` を使用することで正しいフィルタを構築
- この不具合により全コース検索が失敗し、チャット機能が動作しない状態だった

## Root Cause

qdrant_client の `FieldCondition` は `is_null` パラメータをサポートしない。null フィールドのチェックには `IsNullCondition` + `PayloadField` を使う必要がある。

## Test plan

- [x] `pytest tests/` 252 件パス
- [x] `ruff check` / `ruff format` パス

Closes #98