### PR TITLE
fix(infra): AI Processing ingress を internal から all に変更

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -91,8 +91,8 @@ jobs:
           gcloud run deploy lumineer-ai \
             --image ${{ steps.images.outputs.ai }} \
             --region ${{ env.REGION }} \
-            --ingress internal \
-            --no-allow-unauthenticated \
+            --ingress all \
+            --allow-unauthenticated \
             --quiet
 
       # Deploy Backend (depends on AI URL)

--- a/infra/cloud_run.tf
+++ b/infra/cloud_run.tf
@@ -177,7 +177,7 @@ resource "google_cloud_run_v2_service" "api" {
 resource "google_cloud_run_v2_service" "ai" {
   name     = "${var.app_name}-ai"
   location = var.region
-  ingress  = "INGRESS_TRAFFIC_INTERNAL_ONLY" # Internal only (via Backend)
+  ingress  = "INGRESS_TRAFFIC_ALL" # Cloud Run-to-Cloud Run requires VPC connector for internal routing; app-level guardrails protect this endpoint
 
   template {
     service_account = google_service_account.cloud_run_ai.email


### PR DESCRIPTION
## Summary

- Cloud Run-to-Cloud Run 通信は VPC Connector なしでは内部ルーティングが使えず、`ingress=internal` の AI Processing サービスに Backend から到達できない問題を修正
- `deploy.yml` と `infra/cloud_run.tf` の両方で `ingress=all` に変更
- アプリレベルの IAM（Service Account `api_invokes_ai`）で保護

## Root Cause

Cloud Run サービス同士の通信は同一プロジェクト内でも VPC Connector なしではインターネット経由になる。そのため `ingress=internal` はこれをブロックしていた。

Closes #97