### PR TITLE
fix: Docker全サービス起動時の複数バグ修正（idleTimeout + useCourseSearch）

### DIFF
--- a/ai/app/observability/metrics.py
+++ b/ai/app/observability/metrics.py
@@ -65,16 +65,20 @@ class MetricsCollector:
 
 
 def _get_or_create(metric_cls: type, name: str, description: str, **kwargs: Any) -> Any:
-    """Return existing metric if already registered, else create new one."""
+    """Return existing metric if already registered, else create new one.
+
+    On hot-reload the default registry already contains the metric.
+    We unregister it first to allow clean re-creation.
+    """
     reg = kwargs.get("registry", DEFAULT_REGISTRY)
-    try:
-        return metric_cls(name, description, **kwargs)
-    except ValueError:
-        # Already registered — retrieve from registry
-        for collector in list(reg._names_to_collectors.values()):
-            if getattr(collector, "_name", None) == name:
-                return collector
-        raise  # unexpected — re-raise
+    # Check all name variants (Counter adds _total, _created suffixes)
+    existing = reg._names_to_collectors.get(name) or reg._names_to_collectors.get(f"{name}_total")
+    if existing is not None:
+        try:
+            reg.unregister(existing)
+        except Exception:
+            pass
+    return metric_cls(name, description, **kwargs)
 
 
 def create_metrics_collector(*, registry: CollectorRegistry | None = None) -> MetricsCollector:

--- a/ai/main.py
+++ b/ai/main.py
@@ -31,4 +31,5 @@ if __name__ == "__main__":
         host=settings.HOST,
         port=settings.PORT,
         reload=settings.APP_ENV == "dev",
+        reload_dirs=["app"] if settings.APP_ENV == "dev" else None,
     )

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -9,6 +9,7 @@ const app = createRouter(container)
 export default {
   port: settings.PORT,
   fetch: app.fetch,
+  idleTimeout: 120,
 }
 
 console.log(`Lumineer API running on port ${settings.PORT}`)

--- a/backend/src/infrastructure/llm/ai_processing_client.ts
+++ b/backend/src/infrastructure/llm/ai_processing_client.ts
@@ -29,16 +29,17 @@ export class AIProcessingClient implements AIProcessingPort {
 
     const data = (await response.json()) as {
       courses: unknown[]
-      summary: string
-      total: number
+      summary?: string
+      total?: number
+      total_hits?: number
     }
 
     return {
       courses: data.courses.map((c) =>
         CourseFactory.create(c as Parameters<typeof CourseFactory.create>[0]),
       ),
-      summary: data.summary,
-      total: data.total,
+      summary: data.summary ?? "",
+      total: data.total ?? data.total_hits ?? data.courses.length,
     }
   }
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -103,6 +103,7 @@ services:
       - "${AI_PORT:-8001}:8001"
     volumes:
       - ./ai:/app
+      - /app/.venv
     env_file: .env.local
     environment:
       - APP_ENV=dev

--- a/frontend/src/features/explore/hooks/useCourseSearch.ts
+++ b/frontend/src/features/explore/hooks/useCourseSearch.ts
@@ -57,16 +57,17 @@ export function useCourseSearch({
       setError(null)
 
       try {
-        const params = new URLSearchParams({
-          q: debouncedQuery,
-          limit: String(LIMIT),
-          offset: String(currentOffset),
-        })
-        if (level) params.set("level", level)
-        if (minRating) params.set("min_rating", minRating)
+        const body: Record<string, unknown> = {
+          query: debouncedQuery,
+          limit: LIMIT,
+        }
+        if (level) body.level = level
+        if (minRating) body.min_rating = Number(minRating)
 
-        const response = await fetch(`${API_BASE_URL}/api/courses/search?${params.toString()}`, {
+        const response = await fetch(`${API_BASE_URL}/api/search`, {
+          method: "POST",
           headers: { "Content-Type": "application/json", ...getAuthHeaders() },
+          body: JSON.stringify(body),
         })
 
         if (!response.ok) {
@@ -87,8 +88,8 @@ export function useCourseSearch({
         } else {
           setCourses(data.courses)
         }
-        setTotal(data.total)
-        setAiSummary(data.ai_summary)
+        setTotal(data.total ?? data.courses?.length ?? 0)
+        setAiSummary(data.summary ?? data.ai_summary)
       } catch (err) {
         if (fetchId !== fetchIdRef.current) return
         setError(err as ApiError)

--- a/frontend/src/lib/types/course.ts
+++ b/frontend/src/lib/types/course.ts
@@ -16,6 +16,7 @@ export interface Course {
 export interface CourseSearchResult {
   courses: Course[]
   total: number
+  summary?: string
   ai_summary?: string
 }
 

--- a/gateway/src/index.ts
+++ b/gateway/src/index.ts
@@ -33,6 +33,7 @@ app.notFound((c) => c.json({ error: "Not found" }, 404))
 export default {
   port: settings.PORT,
   fetch: app.fetch,
+  idleTimeout: 120,
 }
 
 console.log(`Lumineer Gateway running on port ${settings.PORT}`)


### PR DESCRIPTION
## Summary

- Backend/Gateway: `Bun.serve idleTimeout=10s` で SSE が切断 → 120s に延長（チャット502問題の根本修正）
- Frontend: `useCourseSearch` を `POST /api/search` に修正（`GET /api/courses/search` は存在しないエンドポイントだった）
- Backend: `total_hits → total` マッピング、`summary` 欠損時のフォールバック
- AI: Prometheus メトリクス二重登録 → unregister 後に再登録
- AI: watchfiles が `.venv` を監視して無限リロード → `reload_dirs=["app"]` で制限

Commit: 8a8e622