### PR TITLE
fix: Qdrant timeout + Header FOUC + unused param

### DIFF
--- a/ai/app/config/settings.py
+++ b/ai/app/config/settings.py
@@ -39,7 +39,7 @@ class Settings(BaseSettings):
     PREPROCESSED_PATH: str = "data/processed/preprocessed.jsonl"
     BATCH_SIZE_LLM: int = 10
     BATCH_SIZE_EMBEDDING: int = 100
-    BATCH_SIZE_UPSERT: int = 200
+    BATCH_SIZE_UPSERT: int = 50
     CHUNK_SIZE: int = 600
     CHUNK_OVERLAP: int = 120
 

--- a/ai/app/infrastructure/vectordb/qdrant_adapter.py
+++ b/ai/app/infrastructure/vectordb/qdrant_adapter.py
@@ -20,8 +20,8 @@ DENSE_VECTOR_NAME = "dense"
 SPARSE_VECTOR_NAME = "sparse"
 
 
-def create_client(url: str, api_key: str | None = None) -> QdrantClient:
-    return QdrantClient(url=url, api_key=api_key)
+def create_client(url: str, api_key: str | None = None, timeout: int = 120) -> QdrantClient:
+    return QdrantClient(url=url, api_key=api_key, timeout=timeout)
 
 
 def ensure_collection(

--- a/frontend/src/features/explore/hooks/useCourseSearch.ts
+++ b/frontend/src/features/explore/hooks/useCourseSearch.ts
@@ -43,7 +43,7 @@ export function useCourseSearch({
   const fetchIdRef = useRef(0)
 
   const fetchCourses = useCallback(
-    async (currentOffset: number, append: boolean) => {
+    async (_currentOffset: number, append: boolean) => {
       if (!debouncedQuery.trim()) {
         setCourses([])
         setTotal(0)

--- a/frontend/src/lib/layout/Header.tsx
+++ b/frontend/src/lib/layout/Header.tsx
@@ -15,7 +15,7 @@ const navItems = [
 export function Header() {
   const location = useLocation()
   const navigate = useNavigate()
-  const { user, isAuthenticated, logout } = useAuth()
+  const { user, isAuthenticated, isLoading, logout } = useAuth()
 
   const handleLogout = () => {
     logout()
@@ -51,7 +51,9 @@ export function Header() {
           ))}
 
           <div className="ml-2 flex items-center gap-2 border-l pl-3">
-            {isAuthenticated ? (
+            {isLoading ? (
+              <div className="h-8 w-16 animate-pulse rounded-md bg-muted" />
+            ) : isAuthenticated ? (
               <>
                 <span className="text-sm text-muted-foreground">{user?.display_name}</span>
                 <Button variant="ghost" size="sm" onClick={handleLogout} title="Sign out">


### PR DESCRIPTION
## Summary

- **Qdrant timeout**: `create_client()` now accepts `timeout=120s` (was 5s default), fixing `ResponseHandlingException: timed out` during bulk upsert on e2-micro
- **BATCH_SIZE_UPSERT**: reduced 200 → 50 to lower per-request memory pressure on e2-micro
- **Header FOUC**: show loading skeleton while auth restores on mount — eliminates the "Sign In" flash on direct page navigation
- **useCourseSearch**: prefix unused `_currentOffset` param (backend has no pagination offset support yet)

## Test plan

- [ ] Run `scripts/seed_data.py --skip-llm` targeting remote Qdrant — should complete without timeout
- [ ] Navigate directly to `/explore` while logged in — should show loading skeleton, then username (no "Sign In" flash)
- [ ] `bun run typecheck` passes in frontend

Closes #103
Closes #104